### PR TITLE
Updated assertion tester

### DIFF
--- a/AssertionTester/Assertions/td-vocab-op--Form.json
+++ b/AssertionTester/Assertions/td-vocab-op--Form.json
@@ -134,42 +134,6 @@
                     "href": {
                         "$ref": "#/definitions/url"
                     },
-                    "op": {
-                        "anyOf": [{
-                                "type": "string",
-                                "enum": [
-                                    "readproperty",
-                                    "writeproperty",
-                                    "observeproperty",
-                                    "readallproperties",
-                                    "writeallproperties",
-                                    "readmultipleproperties",
-                                    "writemultipleproperties",
-                                    "subscribeevent",
-                                    "unsubscribeevent",
-                                    "invokeaction"
-                                ]
-                            },
-                            {
-                                "type": "array",
-                                "items": {
-                                    "type": "string",
-                                    "enum": [
-                                        "readproperty",
-                                        "writeproperty",
-                                        "observeproperty",
-                                        "readallproperties",
-                                        "writeallproperties",
-                                        "readmultipleproperties",
-                                        "writemultipleproperties",
-                                        "subscribeevent",
-                                        "unsubscribeevent",
-                                        "invokeaction"
-                                    ]
-                                }
-                            }
-                        ]
-                    },
                     "contentType": {
                         "type": "string"
                     },

--- a/AssertionTester/Assertions/td-vocab-op--Form_invokeaction.json
+++ b/AssertionTester/Assertions/td-vocab-op--Form_invokeaction.json
@@ -1,0 +1,160 @@
+{
+    "title": "td-vocab-op--Form_invokeaction",
+    "description": "op: Indicates the expected result of performing the operation described by the form. For example, the Property interaction allows get and set operations. The protocol binding may contain a form for the get operation and a different form for the set operation. The op attribute indicates which form is which and allows the client to select the correct form for the operation required. ",
+    "$schema ": "http://json-schema.org/draft-06/schema#",
+    "is-complex": true,
+    "type": "object",
+    "properties": {
+        "forms": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "$ref": "#/definitions/form_element"
+            }
+        },
+        "properties": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/property_element"
+            }
+
+        },
+        "actions": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/action_element"
+            }
+        },
+        "events": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/event_element"
+            }
+        }
+
+    },
+    "additionalProperties": true,
+    "definitions": {
+        "property_element": {
+            "type": "object",
+            "properties": {
+                "forms": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/form_element"
+                    }
+                }
+            },
+            "required": [
+                "forms"
+            ],
+            "additionalProperties": true
+        },
+        "action_element": {
+            "type": "object",
+            "properties": {
+                "forms": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/form_element"
+                    }
+                }
+            },
+            "required": [
+                "forms"
+            ],
+            "additionalProperties": true
+        },
+        "event_element": {
+            "type": "object",
+            "properties": {
+                "forms": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/form_element"
+                    }
+                }
+            },
+            "required": [
+                "forms"
+            ],
+            "additionalProperties": true
+        },
+        "form_element": {
+            "type": "object",
+            "if": {
+                "required": ["op"],
+                "properties": {
+                    "op": {
+                        "anyOf": [{
+                                "type": "string",
+                                "enum": [
+                                    "invokeaction"
+                                ]
+                            },
+                            {
+                                "type": "array",
+                                "items": {
+                                    "type": "string",
+                                    "enum": [
+                                        "invokeaction"
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            },
+            "then": {
+                "const": "td-vocab-op--Form_invokeaction=pass"
+            },
+            "else": {
+                "properties": {
+                    "href": {
+                        "$ref": "#/definitions/url"
+                    },
+                    "contentType": {
+                        "type": "string"
+                    },
+                    "security": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "scopes": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "subProtocol": {
+                        "type": "string",
+                        "enum": [
+                            "longpoll", "websub", "sse"
+                        ]
+                    },
+                    "response": {
+                        "type": "object",
+                        "properties": {
+                            "contentType": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "required": [
+                    "href"
+                ],
+                "additionalProperties": true
+            }
+        },
+        "url": {
+            "type": "string",
+            "format": "uri-reference"
+        }
+    }
+}

--- a/AssertionTester/Assertions/td-vocab-op--Form_observeproperty.json
+++ b/AssertionTester/Assertions/td-vocab-op--Form_observeproperty.json
@@ -1,6 +1,6 @@
 {
-    "title": "td-vocab-subprotocol--Form",
-    "description": "subprotocol: Indicates the exact mechanism by which an interaction will be accomplished for a given protocol when there are multiple options. For example, for HTTP and Events, it indicates which of several available mechanisms should be used for asynchronous notifications. ",
+    "title": "td-vocab-op--Form_observeproperty",
+    "description": "op: Indicates the expected result of performing the operation described by the form. For example, the Property interaction allows get and set operations. The protocol binding may contain a form for the get operation and a different form for the set operation. The op attribute indicates which form is which and allows the client to select the correct form for the operation required. ",
     "$schema ": "http://json-schema.org/draft-06/schema#",
     "is-complex": true,
     "type": "object",
@@ -86,18 +86,70 @@
         "form_element": {
             "type": "object",
             "if": {
-                "required": ["subprotocol"],
+                "required": ["op"],
                 "properties": {
-                    "subProtocol": {
-                        "type": "string",
-                        "enum": [
-                            "longpoll","websub","sse"
+                    "op": {
+                        "anyOf": [{
+                                "type": "string",
+                                "enum": [
+                                    "observeproperty"
+                                ]
+                            },
+                            {
+                                "type": "array",
+                                "items": {
+                                    "type": "string",
+                                    "enum": [
+                                        "observeproperty"
+                                    ]
+                                }
+                            }
                         ]
                     }
                 }
             },
             "then": {
-                "const": "td-vocab-subprotocol--Form=pass"
+                "const": "td-vocab-op--Form_observeproperty=pass"
+            },
+            "else": {
+                "properties": {
+                    "href": {
+                        "$ref": "#/definitions/url"
+                    },
+                    "contentType": {
+                        "type": "string"
+                    },
+                    "security": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "scopes": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "subProtocol": {
+                        "type": "string",
+                        "enum": [
+                            "longpoll", "websub", "sse"
+                        ]
+                    },
+                    "response": {
+                        "type": "object",
+                        "properties": {
+                            "contentType": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "required": [
+                    "href"
+                ],
+                "additionalProperties": true
             }
         },
         "url": {

--- a/AssertionTester/Assertions/td-vocab-op--Form_readproperty.json
+++ b/AssertionTester/Assertions/td-vocab-op--Form_readproperty.json
@@ -1,0 +1,160 @@
+{
+    "title": "td-vocab-op--Form_readproperty",
+    "description": "op: Indicates the expected result of performing the operation described by the form. For example, the Property interaction allows get and set operations. The protocol binding may contain a form for the get operation and a different form for the set operation. The op attribute indicates which form is which and allows the client to select the correct form for the operation required. ",
+    "$schema ": "http://json-schema.org/draft-06/schema#",
+    "is-complex": true,
+    "type": "object",
+    "properties": {
+        "forms": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "$ref": "#/definitions/form_element"
+            }
+        },
+        "properties": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/property_element"
+            }
+
+        },
+        "actions": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/action_element"
+            }
+        },
+        "events": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/event_element"
+            }
+        }
+
+    },
+    "additionalProperties": true,
+    "definitions": {
+        "property_element": {
+            "type": "object",
+            "properties": {
+                "forms": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/form_element"
+                    }
+                }
+            },
+            "required": [
+                "forms"
+            ],
+            "additionalProperties": true
+        },
+        "action_element": {
+            "type": "object",
+            "properties": {
+                "forms": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/form_element"
+                    }
+                }
+            },
+            "required": [
+                "forms"
+            ],
+            "additionalProperties": true
+        },
+        "event_element": {
+            "type": "object",
+            "properties": {
+                "forms": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/form_element"
+                    }
+                }
+            },
+            "required": [
+                "forms"
+            ],
+            "additionalProperties": true
+        },
+        "form_element": {
+            "type": "object",
+            "if": {
+                "required": ["op"],
+                "properties": {
+                    "op": {
+                        "anyOf": [{
+                                "type": "string",
+                                "enum": [
+                                    "readproperty"
+                                ]
+                            },
+                            {
+                                "type": "array",
+                                "items": {
+                                    "type": "string",
+                                    "enum": [
+                                        "readproperty"
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            },
+            "then": {
+                "const": "td-vocab-op--Form_readproperty=pass"
+            },
+            "else": {
+                "properties": {
+                    "href": {
+                        "$ref": "#/definitions/url"
+                    },
+                    "contentType": {
+                        "type": "string"
+                    },
+                    "security": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "scopes": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "subProtocol": {
+                        "type": "string",
+                        "enum": [
+                            "longpoll", "websub", "sse"
+                        ]
+                    },
+                    "response": {
+                        "type": "object",
+                        "properties": {
+                            "contentType": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "required": [
+                    "href"
+                ],
+                "additionalProperties": true
+            }
+        },
+        "url": {
+            "type": "string",
+            "format": "uri-reference"
+        }
+    }
+}

--- a/AssertionTester/Assertions/td-vocab-op--Form_subscribeevent.json
+++ b/AssertionTester/Assertions/td-vocab-op--Form_subscribeevent.json
@@ -1,0 +1,160 @@
+{
+    "title": "td-vocab-op--Form_subscribeevent",
+    "description": "op: Indicates the expected result of performing the operation described by the form. For example, the Property interaction allows get and set operations. The protocol binding may contain a form for the get operation and a different form for the set operation. The op attribute indicates which form is which and allows the client to select the correct form for the operation required. ",
+    "$schema ": "http://json-schema.org/draft-06/schema#",
+    "is-complex": true,
+    "type": "object",
+    "properties": {
+        "forms": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "$ref": "#/definitions/form_element"
+            }
+        },
+        "properties": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/property_element"
+            }
+
+        },
+        "actions": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/action_element"
+            }
+        },
+        "events": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/event_element"
+            }
+        }
+
+    },
+    "additionalProperties": true,
+    "definitions": {
+        "property_element": {
+            "type": "object",
+            "properties": {
+                "forms": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/form_element"
+                    }
+                }
+            },
+            "required": [
+                "forms"
+            ],
+            "additionalProperties": true
+        },
+        "action_element": {
+            "type": "object",
+            "properties": {
+                "forms": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/form_element"
+                    }
+                }
+            },
+            "required": [
+                "forms"
+            ],
+            "additionalProperties": true
+        },
+        "event_element": {
+            "type": "object",
+            "properties": {
+                "forms": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/form_element"
+                    }
+                }
+            },
+            "required": [
+                "forms"
+            ],
+            "additionalProperties": true
+        },
+        "form_element": {
+            "type": "object",
+            "if": {
+                "required": ["op"],
+                "properties": {
+                    "op": {
+                        "anyOf": [{
+                                "type": "string",
+                                "enum": [
+                                    "subscribeevent"
+                                ]
+                            },
+                            {
+                                "type": "array",
+                                "items": {
+                                    "type": "string",
+                                    "enum": [
+                                        "subscribeevent"
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            },
+            "then": {
+                "const": "td-vocab-op--Form_subscribeevent=pass"
+            },
+            "else": {
+                "properties": {
+                    "href": {
+                        "$ref": "#/definitions/url"
+                    },
+                    "contentType": {
+                        "type": "string"
+                    },
+                    "security": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "scopes": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "subProtocol": {
+                        "type": "string",
+                        "enum": [
+                            "longpoll", "websub", "sse"
+                        ]
+                    },
+                    "response": {
+                        "type": "object",
+                        "properties": {
+                            "contentType": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "required": [
+                    "href"
+                ],
+                "additionalProperties": true
+            }
+        },
+        "url": {
+            "type": "string",
+            "format": "uri-reference"
+        }
+    }
+}

--- a/AssertionTester/Assertions/td-vocab-op--Form_unobserveproperty.json
+++ b/AssertionTester/Assertions/td-vocab-op--Form_unobserveproperty.json
@@ -1,0 +1,160 @@
+{
+    "title": "td-vocab-op--Form_unobserveproperty",
+    "description": "op: Indicates the expected result of performing the operation described by the form. For example, the Property interaction allows get and set operations. The protocol binding may contain a form for the get operation and a different form for the set operation. The op attribute indicates which form is which and allows the client to select the correct form for the operation required. ",
+    "$schema ": "http://json-schema.org/draft-06/schema#",
+    "is-complex": true,
+    "type": "object",
+    "properties": {
+        "forms": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "$ref": "#/definitions/form_element"
+            }
+        },
+        "properties": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/property_element"
+            }
+
+        },
+        "actions": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/action_element"
+            }
+        },
+        "events": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/event_element"
+            }
+        }
+
+    },
+    "additionalProperties": true,
+    "definitions": {
+        "property_element": {
+            "type": "object",
+            "properties": {
+                "forms": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/form_element"
+                    }
+                }
+            },
+            "required": [
+                "forms"
+            ],
+            "additionalProperties": true
+        },
+        "action_element": {
+            "type": "object",
+            "properties": {
+                "forms": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/form_element"
+                    }
+                }
+            },
+            "required": [
+                "forms"
+            ],
+            "additionalProperties": true
+        },
+        "event_element": {
+            "type": "object",
+            "properties": {
+                "forms": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/form_element"
+                    }
+                }
+            },
+            "required": [
+                "forms"
+            ],
+            "additionalProperties": true
+        },
+        "form_element": {
+            "type": "object",
+            "if": {
+                "required": ["op"],
+                "properties": {
+                    "op": {
+                        "anyOf": [{
+                                "type": "string",
+                                "enum": [
+                                    "unobserveproperty"
+                                ]
+                            },
+                            {
+                                "type": "array",
+                                "items": {
+                                    "type": "string",
+                                    "enum": [
+                                        "unobserveproperty"
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            },
+            "then": {
+                "const": "td-vocab-op--Form_unobserveproperty=pass"
+            },
+            "else": {
+                "properties": {
+                    "href": {
+                        "$ref": "#/definitions/url"
+                    },
+                    "contentType": {
+                        "type": "string"
+                    },
+                    "security": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "scopes": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "subProtocol": {
+                        "type": "string",
+                        "enum": [
+                            "longpoll", "websub", "sse"
+                        ]
+                    },
+                    "response": {
+                        "type": "object",
+                        "properties": {
+                            "contentType": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "required": [
+                    "href"
+                ],
+                "additionalProperties": true
+            }
+        },
+        "url": {
+            "type": "string",
+            "format": "uri-reference"
+        }
+    }
+}

--- a/AssertionTester/Assertions/td-vocab-op--Form_unsubscribeevent.json
+++ b/AssertionTester/Assertions/td-vocab-op--Form_unsubscribeevent.json
@@ -1,5 +1,5 @@
 {
-    "title": "td-vocab-op--Form",
+    "title": "td-vocab-op--Form_unsubscribeevent",
     "description": "op: Indicates the expected result of performing the operation described by the form. For example, the Property interaction allows get and set operations. The protocol binding may contain a form for the get operation and a different form for the set operation. The op attribute indicates which form is which and allows the client to select the correct form for the operation required. ",
     "$schema ": "http://json-schema.org/draft-06/schema#",
     "is-complex": true,
@@ -92,16 +92,7 @@
                         "anyOf": [{
                                 "type": "string",
                                 "enum": [
-                                    "readproperty",
-                                    "writeproperty",
-                                    "observeproperty",
-                                    "readallproperties",
-                                    "writeallproperties",
-                                    "readmultipleproperties",
-                                    "writemultipleproperties",
-                                    "subscribeevent",
-                                    "unsubscribeevent",
-                                    "invokeaction"
+                                    "unsubscribeevent"
                                 ]
                             },
                             {
@@ -109,16 +100,7 @@
                                 "items": {
                                     "type": "string",
                                     "enum": [
-                                        "readproperty",
-                                        "writeproperty",
-                                        "observeproperty",
-                                        "readallproperties",
-                                        "writeallproperties",
-                                        "readmultipleproperties",
-                                        "writemultipleproperties",
-                                        "subscribeevent",
-                                        "unsubscribeevent",
-                                        "invokeaction"
+                                        "unsubscribeevent"
                                     ]
                                 }
                             }
@@ -127,7 +109,7 @@
                 }
             },
             "then": {
-                "const": "td-vocab-op--Form=pass"
+                "const": "td-vocab-op--Form_unsubscribeevent=pass"
             },
             "else": {
                 "properties": {

--- a/AssertionTester/Assertions/td-vocab-op--Form_writeproperty.json
+++ b/AssertionTester/Assertions/td-vocab-op--Form_writeproperty.json
@@ -1,0 +1,160 @@
+{
+    "title": "td-vocab-op--Form_writeproperty",
+    "description": "op: Indicates the expected result of performing the operation described by the form. For example, the Property interaction allows get and set operations. The protocol binding may contain a form for the get operation and a different form for the set operation. The op attribute indicates which form is which and allows the client to select the correct form for the operation required. ",
+    "$schema ": "http://json-schema.org/draft-06/schema#",
+    "is-complex": true,
+    "type": "object",
+    "properties": {
+        "forms": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "$ref": "#/definitions/form_element"
+            }
+        },
+        "properties": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/property_element"
+            }
+
+        },
+        "actions": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/action_element"
+            }
+        },
+        "events": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/event_element"
+            }
+        }
+
+    },
+    "additionalProperties": true,
+    "definitions": {
+        "property_element": {
+            "type": "object",
+            "properties": {
+                "forms": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/form_element"
+                    }
+                }
+            },
+            "required": [
+                "forms"
+            ],
+            "additionalProperties": true
+        },
+        "action_element": {
+            "type": "object",
+            "properties": {
+                "forms": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/form_element"
+                    }
+                }
+            },
+            "required": [
+                "forms"
+            ],
+            "additionalProperties": true
+        },
+        "event_element": {
+            "type": "object",
+            "properties": {
+                "forms": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/form_element"
+                    }
+                }
+            },
+            "required": [
+                "forms"
+            ],
+            "additionalProperties": true
+        },
+        "form_element": {
+            "type": "object",
+            "if": {
+                "required": ["op"],
+                "properties": {
+                    "op": {
+                        "anyOf": [{
+                                "type": "string",
+                                "enum": [
+                                    "writeproperty"
+                                ]
+                            },
+                            {
+                                "type": "array",
+                                "items": {
+                                    "type": "string",
+                                    "enum": [
+                                        "writeproperty"
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            },
+            "then": {
+                "const": "td-vocab-op--Form_writeproperty=pass"
+            },
+            "else": {
+                "properties": {
+                    "href": {
+                        "$ref": "#/definitions/url"
+                    },
+                    "contentType": {
+                        "type": "string"
+                    },
+                    "security": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "scopes": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "subProtocol": {
+                        "type": "string",
+                        "enum": [
+                            "longpoll", "websub", "sse"
+                        ]
+                    },
+                    "response": {
+                        "type": "object",
+                        "properties": {
+                            "contentType": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "required": [
+                    "href"
+                ],
+                "additionalProperties": true
+            }
+        },
+        "url": {
+            "type": "string",
+            "format": "uri-reference"
+        }
+    }
+}

--- a/AssertionTester/Assertions/td-vocab-scheme--SecurityScheme_apikey.json
+++ b/AssertionTester/Assertions/td-vocab-scheme--SecurityScheme_apikey.json
@@ -1,0 +1,39 @@
+{
+    "title": "td-vocab-scheme--SecurityScheme_apikey",
+    "description": "scheme: Identification of security mechanism being configured. MUST be included. Type: string apikey.",
+    "$schema ": "http://json-schema.org/draft-06/schema#",
+    "is-complex": true,
+    "type": "object",
+    "properties": {
+        "securityDefinitions": {
+            "type": "object",
+            "minProperties": 1,
+            "additionalProperties": {
+                "$ref": "#/definitions/securityScheme"
+            }
+        }
+    },
+    "required": [
+        "securityDefinitions"
+    ],
+    "additionalProperties": true,
+    "definitions": {
+        "securityScheme": {
+            "if": {
+                "type": "object",
+                "properties": {
+                    "scheme": {
+                        "type": "string",
+                        "enum": [
+                            "apikey"
+                        ]
+                    }
+                },
+                "required": ["scheme"]
+            },
+            "then": {
+                "const": "td-vocab-scheme--SecurityScheme_apikey=pass"
+            }
+        }
+    }
+}

--- a/AssertionTester/Assertions/td-vocab-scheme--SecurityScheme_basic.json
+++ b/AssertionTester/Assertions/td-vocab-scheme--SecurityScheme_basic.json
@@ -1,0 +1,39 @@
+{
+    "title": "td-vocab-scheme--SecurityScheme_basic",
+    "description": "scheme: Identification of security mechanism being configured. MUST be included. Type: string basic.",
+    "$schema ": "http://json-schema.org/draft-06/schema#",
+    "is-complex": true,
+    "type": "object",
+    "properties": {
+        "securityDefinitions": {
+            "type": "object",
+            "minProperties": 1,
+            "additionalProperties": {
+                "$ref": "#/definitions/securityScheme"
+            }
+        }
+    },
+    "required": [
+        "securityDefinitions"
+    ],
+    "additionalProperties": true,
+    "definitions": {
+        "securityScheme": {
+            "if": {
+                "type": "object",
+                "properties": {
+                    "scheme": {
+                        "type": "string",
+                        "enum": [
+                            "basic"
+                        ]
+                    }
+                },
+                "required": ["scheme"]
+            },
+            "then": {
+                "const": "td-vocab-scheme--SecurityScheme_basic=pass"
+            }
+        }
+    }
+}

--- a/AssertionTester/Assertions/td-vocab-scheme--SecurityScheme_bearer.json
+++ b/AssertionTester/Assertions/td-vocab-scheme--SecurityScheme_bearer.json
@@ -1,0 +1,39 @@
+{
+    "title": "td-vocab-scheme--SecurityScheme_bearer",
+    "description": "scheme: Identification of security mechanism being configured. MUST be included. Type: string bearer.",
+    "$schema ": "http://json-schema.org/draft-06/schema#",
+    "is-complex": true,
+    "type": "object",
+    "properties": {
+        "securityDefinitions": {
+            "type": "object",
+            "minProperties": 1,
+            "additionalProperties": {
+                "$ref": "#/definitions/securityScheme"
+            }
+        }
+    },
+    "required": [
+        "securityDefinitions"
+    ],
+    "additionalProperties": true,
+    "definitions": {
+        "securityScheme": {
+            "if": {
+                "type": "object",
+                "properties": {
+                    "scheme": {
+                        "type": "string",
+                        "enum": [
+                            "bearer"
+                        ]
+                    }
+                },
+                "required": ["scheme"]
+            },
+            "then": {
+                "const": "td-vocab-scheme--SecurityScheme_bearer=pass"
+            }
+        }
+    }
+}

--- a/AssertionTester/Assertions/td-vocab-scheme--SecurityScheme_cert.json
+++ b/AssertionTester/Assertions/td-vocab-scheme--SecurityScheme_cert.json
@@ -1,0 +1,39 @@
+{
+    "title": "td-vocab-scheme--SecurityScheme_cert",
+    "description": "scheme: Identification of security mechanism being configured. MUST be included. Type: string cert.",
+    "$schema ": "http://json-schema.org/draft-06/schema#",
+    "is-complex": true,
+    "type": "object",
+    "properties": {
+        "securityDefinitions": {
+            "type": "object",
+            "minProperties": 1,
+            "additionalProperties": {
+                "$ref": "#/definitions/securityScheme"
+            }
+        }
+    },
+    "required": [
+        "securityDefinitions"
+    ],
+    "additionalProperties": true,
+    "definitions": {
+        "securityScheme": {
+            "if": {
+                "type": "object",
+                "properties": {
+                    "scheme": {
+                        "type": "string",
+                        "enum": [
+                            "cert"
+                        ]
+                    }
+                },
+                "required": ["scheme"]
+            },
+            "then": {
+                "const": "td-vocab-scheme--SecurityScheme_cert=pass"
+            }
+        }
+    }
+}

--- a/AssertionTester/Assertions/td-vocab-scheme--SecurityScheme_digest.json
+++ b/AssertionTester/Assertions/td-vocab-scheme--SecurityScheme_digest.json
@@ -1,0 +1,39 @@
+{
+    "title": "td-vocab-scheme--SecurityScheme_digest",
+    "description": "scheme: Identification of security mechanism being configured. MUST be included. Type: string digest.",
+    "$schema ": "http://json-schema.org/draft-06/schema#",
+    "is-complex": true,
+    "type": "object",
+    "properties": {
+        "securityDefinitions": {
+            "type": "object",
+            "minProperties": 1,
+            "additionalProperties": {
+                "$ref": "#/definitions/securityScheme"
+            }
+        }
+    },
+    "required": [
+        "securityDefinitions"
+    ],
+    "additionalProperties": true,
+    "definitions": {
+        "securityScheme": {
+            "if": {
+                "type": "object",
+                "properties": {
+                    "scheme": {
+                        "type": "string",
+                        "enum": [
+                            "digest"
+                        ]
+                    }
+                },
+                "required": ["scheme"]
+            },
+            "then": {
+                "const": "td-vocab-scheme--SecurityScheme_digest=pass"
+            }
+        }
+    }
+}

--- a/AssertionTester/Assertions/td-vocab-scheme--SecurityScheme_nosec.json
+++ b/AssertionTester/Assertions/td-vocab-scheme--SecurityScheme_nosec.json
@@ -32,7 +32,7 @@
                 "required": ["scheme"]
             },
             "then": {
-                "const": "td-vocab-scheme--SecurityScheme_nosec"
+                "const": "td-vocab-scheme--SecurityScheme_nosec=pass"
             }
         }
     }

--- a/AssertionTester/Assertions/td-vocab-scheme--SecurityScheme_nosec.json
+++ b/AssertionTester/Assertions/td-vocab-scheme--SecurityScheme_nosec.json
@@ -1,0 +1,39 @@
+{
+    "title": "td-vocab-scheme--SecurityScheme_nosec",
+    "description": "scheme: Identification of security mechanism being configured. MUST be included. Type: string nosec.",
+    "$schema ": "http://json-schema.org/draft-06/schema#",
+    "is-complex": true,
+    "type": "object",
+    "properties": {
+        "securityDefinitions": {
+            "type": "object",
+            "minProperties": 1,
+            "additionalProperties": {
+                "$ref": "#/definitions/securityScheme"
+            }
+        }
+    },
+    "required": [
+        "securityDefinitions"
+    ],
+    "additionalProperties": true,
+    "definitions": {
+        "securityScheme": {
+            "if": {
+                "type": "object",
+                "properties": {
+                    "scheme": {
+                        "type": "string",
+                        "enum": [
+                            "nosec"
+                        ]
+                    }
+                },
+                "required": ["scheme"]
+            },
+            "then": {
+                "const": "td-vocab-scheme--SecurityScheme_nosec"
+            }
+        }
+    }
+}

--- a/AssertionTester/Assertions/td-vocab-scheme--SecurityScheme_oauth2.json
+++ b/AssertionTester/Assertions/td-vocab-scheme--SecurityScheme_oauth2.json
@@ -1,0 +1,39 @@
+{
+    "title": "td-vocab-scheme--SecurityScheme_oauth2",
+    "description": "scheme: Identification of security mechanism being configured. MUST be included. Type: string oauth2.",
+    "$schema ": "http://json-schema.org/draft-06/schema#",
+    "is-complex": true,
+    "type": "object",
+    "properties": {
+        "securityDefinitions": {
+            "type": "object",
+            "minProperties": 1,
+            "additionalProperties": {
+                "$ref": "#/definitions/securityScheme"
+            }
+        }
+    },
+    "required": [
+        "securityDefinitions"
+    ],
+    "additionalProperties": true,
+    "definitions": {
+        "securityScheme": {
+            "if": {
+                "type": "object",
+                "properties": {
+                    "scheme": {
+                        "type": "string",
+                        "enum": [
+                            "oauth2"
+                        ]
+                    }
+                },
+                "required": ["scheme"]
+            },
+            "then": {
+                "const": "td-vocab-scheme--SecurityScheme_oauth2=pass"
+            }
+        }
+    }
+}

--- a/AssertionTester/Assertions/td-vocab-scheme--SecurityScheme_pop.json
+++ b/AssertionTester/Assertions/td-vocab-scheme--SecurityScheme_pop.json
@@ -1,0 +1,39 @@
+{
+    "title": "td-vocab-scheme--SecurityScheme_pop",
+    "description": "scheme: Identification of security mechanism being configured. MUST be included. Type: string pop.",
+    "$schema ": "http://json-schema.org/draft-06/schema#",
+    "is-complex": true,
+    "type": "object",
+    "properties": {
+        "securityDefinitions": {
+            "type": "object",
+            "minProperties": 1,
+            "additionalProperties": {
+                "$ref": "#/definitions/securityScheme"
+            }
+        }
+    },
+    "required": [
+        "securityDefinitions"
+    ],
+    "additionalProperties": true,
+    "definitions": {
+        "securityScheme": {
+            "if": {
+                "type": "object",
+                "properties": {
+                    "scheme": {
+                        "type": "string",
+                        "enum": [
+                            "pop"
+                        ]
+                    }
+                },
+                "required": ["scheme"]
+            },
+            "then": {
+                "const": "td-vocab-scheme--SecurityScheme_pop=pass"
+            }
+        }
+    }
+}

--- a/AssertionTester/Assertions/td-vocab-scheme--SecurityScheme_psk.json
+++ b/AssertionTester/Assertions/td-vocab-scheme--SecurityScheme_psk.json
@@ -1,0 +1,39 @@
+{
+    "title": "td-vocab-scheme--SecurityScheme_psk",
+    "description": "scheme: Identification of security mechanism being configured. MUST be included. Type: string psk.",
+    "$schema ": "http://json-schema.org/draft-06/schema#",
+    "is-complex": true,
+    "type": "object",
+    "properties": {
+        "securityDefinitions": {
+            "type": "object",
+            "minProperties": 1,
+            "additionalProperties": {
+                "$ref": "#/definitions/securityScheme"
+            }
+        }
+    },
+    "required": [
+        "securityDefinitions"
+    ],
+    "additionalProperties": true,
+    "definitions": {
+        "securityScheme": {
+            "if": {
+                "type": "object",
+                "properties": {
+                    "scheme": {
+                        "type": "string",
+                        "enum": [
+                            "psk"
+                        ]
+                    }
+                },
+                "required": ["scheme"]
+            },
+            "then": {
+                "const": "td-vocab-scheme--SecurityScheme_psk=pass"
+            }
+        }
+    }
+}

--- a/AssertionTester/Assertions/td-vocab-scheme--SecurityScheme_public.json
+++ b/AssertionTester/Assertions/td-vocab-scheme--SecurityScheme_public.json
@@ -1,0 +1,39 @@
+{
+    "title": "td-vocab-scheme--SecurityScheme_public",
+    "description": "scheme: Identification of security mechanism being configured. MUST be included. Type: string public.",
+    "$schema ": "http://json-schema.org/draft-06/schema#",
+    "is-complex": true,
+    "type": "object",
+    "properties": {
+        "securityDefinitions": {
+            "type": "object",
+            "minProperties": 1,
+            "additionalProperties": {
+                "$ref": "#/definitions/securityScheme"
+            }
+        }
+    },
+    "required": [
+        "securityDefinitions"
+    ],
+    "additionalProperties": true,
+    "definitions": {
+        "securityScheme": {
+            "if": {
+                "type": "object",
+                "properties": {
+                    "scheme": {
+                        "type": "string",
+                        "enum": [
+                            "public"
+                        ]
+                    }
+                },
+                "required": ["scheme"]
+            },
+            "then": {
+                "const": "td-vocab-scheme--SecurityScheme_public=pass"
+            }
+        }
+    }
+}

--- a/AssertionTester/Assertions/td-vocab-subprotocol--Form_longpoll.json
+++ b/AssertionTester/Assertions/td-vocab-subprotocol--Form_longpoll.json
@@ -1,0 +1,108 @@
+{
+    "title": "td-vocab-subprotocol--Form_longpoll",
+    "description": "subprotocol: Indicates the exact mechanism by which an interaction will be accomplished for a given protocol when there are multiple options. For example, for HTTP and Events, it indicates which of several available mechanisms should be used for asynchronous notifications. ",
+    "$schema ": "http://json-schema.org/draft-06/schema#",
+    "is-complex": true,
+    "type": "object",
+    "properties": {
+        "forms": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "$ref": "#/definitions/form_element"
+            }
+        },
+        "properties": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/property_element"
+            }
+
+        },
+        "actions": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/action_element"
+            }
+        },
+        "events": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/event_element"
+            }
+        }
+
+    },
+    "additionalProperties": true,
+    "definitions": {
+        "property_element": {
+            "type": "object",
+            "properties": {
+                "forms": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/form_element"
+                    }
+                }
+            },
+            "required": [
+                "forms"
+            ],
+            "additionalProperties": true
+        },
+        "action_element": {
+            "type": "object",
+            "properties": {
+                "forms": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/form_element"
+                    }
+                }
+            },
+            "required": [
+                "forms"
+            ],
+            "additionalProperties": true
+        },
+        "event_element": {
+            "type": "object",
+            "properties": {
+                "forms": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/form_element"
+                    }
+                }
+            },
+            "required": [
+                "forms"
+            ],
+            "additionalProperties": true
+        },
+        "form_element": {
+            "type": "object",
+            "if": {
+                "required": ["subprotocol"],
+                "properties": {
+                    "subProtocol": {
+                        "type": "string",
+                        "enum": [
+                            "longpoll"
+                        ]
+                    }
+                }
+            },
+            "then": {
+                "const": "td-vocab-subprotocol--Form_longpoll=pass"
+            }
+        },
+        "url": {
+            "type": "string",
+            "format": "uri-reference"
+        }
+    }
+}

--- a/AssertionTester/Assertions/td-vocab-subprotocol--Form_sse.json
+++ b/AssertionTester/Assertions/td-vocab-subprotocol--Form_sse.json
@@ -1,0 +1,107 @@
+{
+    "title": "td-vocab-subprotocol--Form_sse",
+    "description": "subprotocol: Indicates the exact mechanism by which an interaction will be accomplished for a given protocol when there are multiple options. For example, for HTTP and Events, it indicates which of several available mechanisms should be used for asynchronous notifications. ",
+    "$schema ": "http://json-schema.org/draft-06/schema#",
+    "is-complex": true,
+    "type": "object",
+    "properties": {
+        "forms": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "$ref": "#/definitions/form_element"
+            }
+        },
+        "properties": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/property_element"
+            }
+
+        },
+        "actions": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/action_element"
+            }
+        },
+        "events": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/event_element"
+            }
+        }
+    },
+    "additionalProperties": true,
+    "definitions": {
+        "property_element": {
+            "type": "object",
+            "properties": {
+                "forms": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/form_element"
+                    }
+                }
+            },
+            "required": [
+                "forms"
+            ],
+            "additionalProperties": true
+        },
+        "action_element": {
+            "type": "object",
+            "properties": {
+                "forms": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/form_element"
+                    }
+                }
+            },
+            "required": [
+                "forms"
+            ],
+            "additionalProperties": true
+        },
+        "event_element": {
+            "type": "object",
+            "properties": {
+                "forms": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/form_element"
+                    }
+                }
+            },
+            "required": [
+                "forms"
+            ],
+            "additionalProperties": true
+        },
+        "form_element": {
+            "type": "object",
+            "if": {
+                "required": ["subprotocol"],
+                "properties": {
+                    "subProtocol": {
+                        "type": "string",
+                        "enum": [
+                            "sse"
+                        ]
+                    }
+                }
+            },
+            "then": {
+                "const": "td-vocab-subprotocol--Form_sse=pass"
+            }
+        },
+        "url": {
+            "type": "string",
+            "format": "uri-reference"
+        }
+    }
+}

--- a/AssertionTester/Assertions/td-vocab-subprotocol--Form_websub.json
+++ b/AssertionTester/Assertions/td-vocab-subprotocol--Form_websub.json
@@ -1,0 +1,108 @@
+{
+    "title": "td-vocab-subprotocol--Form_websub",
+    "description": "subprotocol: Indicates the exact mechanism by which an interaction will be accomplished for a given protocol when there are multiple options. For example, for HTTP and Events, it indicates which of several available mechanisms should be used for asynchronous notifications. ",
+    "$schema ": "http://json-schema.org/draft-06/schema#",
+    "is-complex": true,
+    "type": "object",
+    "properties": {
+        "forms": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "$ref": "#/definitions/form_element"
+            }
+        },
+        "properties": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/property_element"
+            }
+
+        },
+        "actions": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/action_element"
+            }
+        },
+        "events": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/event_element"
+            }
+        }
+
+    },
+    "additionalProperties": true,
+    "definitions": {
+        "property_element": {
+            "type": "object",
+            "properties": {
+                "forms": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/form_element"
+                    }
+                }
+            },
+            "required": [
+                "forms"
+            ],
+            "additionalProperties": true
+        },
+        "action_element": {
+            "type": "object",
+            "properties": {
+                "forms": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/form_element"
+                    }
+                }
+            },
+            "required": [
+                "forms"
+            ],
+            "additionalProperties": true
+        },
+        "event_element": {
+            "type": "object",
+            "properties": {
+                "forms": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/form_element"
+                    }
+                }
+            },
+            "required": [
+                "forms"
+            ],
+            "additionalProperties": true
+        },
+        "form_element": {
+            "type": "object",
+            "if": {
+                "required": ["subprotocol"],
+                "properties": {
+                    "subProtocol": {
+                        "type": "string",
+                        "enum": [
+                            "websub"
+                        ]
+                    }
+                }
+            },
+            "then": {
+                "const": "td-vocab-subprotocol--Form_websub=pass"
+            }
+        },
+        "url": {
+            "type": "string",
+            "format": "uri-reference"
+        }
+    }
+}

--- a/AssertionTester/Assertions/td-vocab-type--DataSchema_array.json
+++ b/AssertionTester/Assertions/td-vocab-type--DataSchema_array.json
@@ -1,0 +1,211 @@
+{
+    "title": "td-vocab-type--DataSchema_array",
+    "description": "type: Assignment of JSON-based data types compatible with JSON Schema (one of boolean, integer, number, string, object, array, or null). MAY be included. Type: string array).",
+    "$schema ": "http://json-schema.org/draft-06/schema#",
+    "also": ["td-data-schema_type"],
+    "is-complex": true,
+    "type": "object",
+    "properties": {
+        "properties": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/property_element"
+            }
+        },
+        "actions": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/action_element"
+            }
+        },
+        "events": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/event_element"
+            }
+        }
+    },
+    "additionalProperties": true,
+    "definitions": {
+        "property_element": {
+            "type": "object",
+            "if": {
+                "required": ["type"],
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "array"
+                        ]
+                    }
+                }
+            },
+            "then": {
+                "const": "td-vocab-type--DataSchema_array=pass"
+            },
+            "else": {
+                "properties": {
+                    "uriVariables": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "$ref": "#/definitions/dataSchema"
+                        }
+                    },
+                    "oneOf": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/dataSchema"
+                        }
+                    },
+                    "items": {
+                        "$ref": "#/definitions/dataSchema"
+                    },
+                    "properties": {
+                        "additionalProperties": {
+                            "$ref": "#/definitions/dataSchema"
+                        }
+                    }
+                }
+            }
+        },
+        "action_element": {
+            "type": "object",
+            "properties": {
+                "input": {
+                    "$ref": "#/definitions/dataSchema"
+                },
+                "output": {
+                    "$ref": "#/definitions/dataSchema"
+                }
+            }
+        },
+        "event_element": {
+            "type": "object",
+            "properties": {
+                "subscription": {
+                    "$ref": "#/definitions/dataSchema"
+                },
+                "data": {
+                    "$ref": "#/definitions/dataSchema"
+                },
+                "cancellation": {
+                    "$ref": "#/definitions/dataSchema"
+                }
+            }
+        },
+        "dataSchema": {
+            "type": "object",
+            "if": {
+                "required": ["type"],
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "array"
+                        ]
+                    }
+                }
+            },
+            "then": {
+                "const": "td-vocab-type--DataSchema_array=pass"
+            },
+            "else": {
+                "properties": {
+                    "description": {
+                        "$ref": "#/definitions/description"
+                    },
+                    "title": {
+                        "$ref": "#/definitions/title"
+                    },
+                    "descriptions": {
+                        "$ref": "#/definitions/descriptions"
+                    },
+                    "titles": {
+                        "$ref": "#/definitions/titles"
+                    },
+                    "writeOnly": {
+                        "type": "boolean"
+                    },
+                    "readOnly": {
+                        "type": "boolean"
+                    },
+                    "oneOf": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/dataSchema"
+                        }
+                    },
+                    "unit": {
+                        "type": "string"
+                    },
+                    "enum": {
+                        "type": "array",
+                        "minItems": 1,
+                        "uniqueItems": true
+                    },
+                    "const": {},
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "boolean",
+                            "integer",
+                            "number",
+                            "string",
+                            "object",
+                            "array",
+                            "null"
+                        ]
+                    },
+                    "items": {
+                        "$ref": "#/definitions/dataSchema"
+                    },
+                    "maxItems": {
+
+                        "type": "integer",
+                        "minimum": 0
+
+                    },
+                    "minItems": {
+
+                        "type": "integer",
+                        "minimum": 0
+
+                    },
+                    "minimum": {
+                        "type": "number"
+                    },
+                    "maximum": {
+                        "type": "number"
+                    },
+                    "properties": {
+                        "additionalProperties": {
+                            "$ref": "#/definitions/dataSchema"
+                        }
+                    },
+                    "required": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "description": {
+            "type": "string"
+        },
+        "title": {
+            "type": "string"
+        },
+        "descriptions": {
+            "type": "object"
+        },
+        "titles": {
+            "type": "object"
+        },
+        "url": {
+            "type": "string",
+            "format": "uri-reference"
+        }
+    }
+}

--- a/AssertionTester/Assertions/td-vocab-type--DataSchema_boolean.json
+++ b/AssertionTester/Assertions/td-vocab-type--DataSchema_boolean.json
@@ -1,0 +1,211 @@
+{
+    "title": "td-vocab-type--DataSchema_boolean",
+    "description": "type: Assignment of JSON-based data types compatible with JSON Schema (one of boolean, integer, number, string, object, array, or null). MAY be included. Type: string boolean).",
+    "$schema ": "http://json-schema.org/draft-06/schema#",
+    "also": ["td-data-schema_type"],
+    "is-complex": true,
+    "type": "object",
+    "properties": {
+        "properties": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/property_element"
+            }
+        },
+        "actions": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/action_element"
+            }
+        },
+        "events": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/event_element"
+            }
+        }
+    },
+    "additionalProperties": true,
+    "definitions": {
+        "property_element": {
+            "type": "object",
+            "if": {
+                "required": ["type"],
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "boolean"
+                        ]
+                    }
+                }
+            },
+            "then": {
+                "const": "td-vocab-type--DataSchema_boolean=pass"
+            },
+            "else": {
+                "properties": {
+                    "uriVariables": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "$ref": "#/definitions/dataSchema"
+                        }
+                    },
+                    "oneOf": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/dataSchema"
+                        }
+                    },
+                    "items": {
+                        "$ref": "#/definitions/dataSchema"
+                    },
+                    "properties": {
+                        "additionalProperties": {
+                            "$ref": "#/definitions/dataSchema"
+                        }
+                    }
+                }
+            }
+        },
+        "action_element": {
+            "type": "object",
+            "properties": {
+                "input": {
+                    "$ref": "#/definitions/dataSchema"
+                },
+                "output": {
+                    "$ref": "#/definitions/dataSchema"
+                }
+            }
+        },
+        "event_element": {
+            "type": "object",
+            "properties": {
+                "subscription": {
+                    "$ref": "#/definitions/dataSchema"
+                },
+                "data": {
+                    "$ref": "#/definitions/dataSchema"
+                },
+                "cancellation": {
+                    "$ref": "#/definitions/dataSchema"
+                }
+            }
+        },
+        "dataSchema": {
+            "type": "object",
+            "if": {
+                "required": ["type"],
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "boolean"
+                        ]
+                    }
+                }
+            },
+            "then": {
+                "const": "td-vocab-type--DataSchema_boolean=pass"
+            },
+            "else": {
+                "properties": {
+                    "description": {
+                        "$ref": "#/definitions/description"
+                    },
+                    "title": {
+                        "$ref": "#/definitions/title"
+                    },
+                    "descriptions": {
+                        "$ref": "#/definitions/descriptions"
+                    },
+                    "titles": {
+                        "$ref": "#/definitions/titles"
+                    },
+                    "writeOnly": {
+                        "type": "boolean"
+                    },
+                    "readOnly": {
+                        "type": "boolean"
+                    },
+                    "oneOf": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/dataSchema"
+                        }
+                    },
+                    "unit": {
+                        "type": "string"
+                    },
+                    "enum": {
+                        "type": "array",
+                        "minItems": 1,
+                        "uniqueItems": true
+                    },
+                    "const": {},
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "boolean",
+                            "integer",
+                            "number",
+                            "string",
+                            "object",
+                            "array",
+                            "null"
+                        ]
+                    },
+                    "items": {
+                        "$ref": "#/definitions/dataSchema"
+                    },
+                    "maxItems": {
+
+                        "type": "integer",
+                        "minimum": 0
+
+                    },
+                    "minItems": {
+
+                        "type": "integer",
+                        "minimum": 0
+
+                    },
+                    "minimum": {
+                        "type": "number"
+                    },
+                    "maximum": {
+                        "type": "number"
+                    },
+                    "properties": {
+                        "additionalProperties": {
+                            "$ref": "#/definitions/dataSchema"
+                        }
+                    },
+                    "required": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "description": {
+            "type": "string"
+        },
+        "title": {
+            "type": "string"
+        },
+        "descriptions": {
+            "type": "object"
+        },
+        "titles": {
+            "type": "object"
+        },
+        "url": {
+            "type": "string",
+            "format": "uri-reference"
+        }
+    }
+}

--- a/AssertionTester/Assertions/td-vocab-type--DataSchema_integer.json
+++ b/AssertionTester/Assertions/td-vocab-type--DataSchema_integer.json
@@ -1,0 +1,211 @@
+{
+    "title": "td-vocab-type--DataSchema_integer",
+    "description": "type: Assignment of JSON-based data types compatible with JSON Schema (one of boolean, integer, number, string, object, array, or null). MAY be included. Type: string integer).",
+    "$schema ": "http://json-schema.org/draft-06/schema#",
+    "also": ["td-data-schema_type"],
+    "is-complex": true,
+    "type": "object",
+    "properties": {
+        "properties": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/property_element"
+            }
+        },
+        "actions": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/action_element"
+            }
+        },
+        "events": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/event_element"
+            }
+        }
+    },
+    "additionalProperties": true,
+    "definitions": {
+        "property_element": {
+            "type": "object",
+            "if": {
+                "required": ["type"],
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "integer"
+                        ]
+                    }
+                }
+            },
+            "then": {
+                "const": "td-vocab-type--DataSchema_integer=pass"
+            },
+            "else": {
+                "properties": {
+                    "uriVariables": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "$ref": "#/definitions/dataSchema"
+                        }
+                    },
+                    "oneOf": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/dataSchema"
+                        }
+                    },
+                    "items": {
+                        "$ref": "#/definitions/dataSchema"
+                    },
+                    "properties": {
+                        "additionalProperties": {
+                            "$ref": "#/definitions/dataSchema"
+                        }
+                    }
+                }
+            }
+        },
+        "action_element": {
+            "type": "object",
+            "properties": {
+                "input": {
+                    "$ref": "#/definitions/dataSchema"
+                },
+                "output": {
+                    "$ref": "#/definitions/dataSchema"
+                }
+            }
+        },
+        "event_element": {
+            "type": "object",
+            "properties": {
+                "subscription": {
+                    "$ref": "#/definitions/dataSchema"
+                },
+                "data": {
+                    "$ref": "#/definitions/dataSchema"
+                },
+                "cancellation": {
+                    "$ref": "#/definitions/dataSchema"
+                }
+            }
+        },
+        "dataSchema": {
+            "type": "object",
+            "if": {
+                "required": ["type"],
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "integer"
+                        ]
+                    }
+                }
+            },
+            "then": {
+                "const": "td-vocab-type--DataSchema_integer=pass"
+            },
+            "else": {
+                "properties": {
+                    "description": {
+                        "$ref": "#/definitions/description"
+                    },
+                    "title": {
+                        "$ref": "#/definitions/title"
+                    },
+                    "descriptions": {
+                        "$ref": "#/definitions/descriptions"
+                    },
+                    "titles": {
+                        "$ref": "#/definitions/titles"
+                    },
+                    "writeOnly": {
+                        "type": "boolean"
+                    },
+                    "readOnly": {
+                        "type": "boolean"
+                    },
+                    "oneOf": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/dataSchema"
+                        }
+                    },
+                    "unit": {
+                        "type": "string"
+                    },
+                    "enum": {
+                        "type": "array",
+                        "minItems": 1,
+                        "uniqueItems": true
+                    },
+                    "const": {},
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "boolean",
+                            "integer",
+                            "number",
+                            "string",
+                            "object",
+                            "array",
+                            "null"
+                        ]
+                    },
+                    "items": {
+                        "$ref": "#/definitions/dataSchema"
+                    },
+                    "maxItems": {
+
+                        "type": "integer",
+                        "minimum": 0
+
+                    },
+                    "minItems": {
+
+                        "type": "integer",
+                        "minimum": 0
+
+                    },
+                    "minimum": {
+                        "type": "number"
+                    },
+                    "maximum": {
+                        "type": "number"
+                    },
+                    "properties": {
+                        "additionalProperties": {
+                            "$ref": "#/definitions/dataSchema"
+                        }
+                    },
+                    "required": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "description": {
+            "type": "string"
+        },
+        "title": {
+            "type": "string"
+        },
+        "descriptions": {
+            "type": "object"
+        },
+        "titles": {
+            "type": "object"
+        },
+        "url": {
+            "type": "string",
+            "format": "uri-reference"
+        }
+    }
+}

--- a/AssertionTester/Assertions/td-vocab-type--DataSchema_null.json
+++ b/AssertionTester/Assertions/td-vocab-type--DataSchema_null.json
@@ -1,0 +1,211 @@
+{
+    "title": "td-vocab-type--DataSchema_null",
+    "description": "type: Assignment of JSON-based data types compatible with JSON Schema (one of boolean, integer, number, string, object, array, or null). MAY be included. Type: string null).",
+    "$schema ": "http://json-schema.org/draft-06/schema#",
+    "also": ["td-data-schema_type"],
+    "is-complex": true,
+    "type": "object",
+    "properties": {
+        "properties": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/property_element"
+            }
+        },
+        "actions": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/action_element"
+            }
+        },
+        "events": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/event_element"
+            }
+        }
+    },
+    "additionalProperties": true,
+    "definitions": {
+        "property_element": {
+            "type": "object",
+            "if": {
+                "required": ["type"],
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "null"
+                        ]
+                    }
+                }
+            },
+            "then": {
+                "const": "td-vocab-type--DataSchema_null=pass"
+            },
+            "else": {
+                "properties": {
+                    "uriVariables": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "$ref": "#/definitions/dataSchema"
+                        }
+                    },
+                    "oneOf": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/dataSchema"
+                        }
+                    },
+                    "items": {
+                        "$ref": "#/definitions/dataSchema"
+                    },
+                    "properties": {
+                        "additionalProperties": {
+                            "$ref": "#/definitions/dataSchema"
+                        }
+                    }
+                }
+            }
+        },
+        "action_element": {
+            "type": "object",
+            "properties": {
+                "input": {
+                    "$ref": "#/definitions/dataSchema"
+                },
+                "output": {
+                    "$ref": "#/definitions/dataSchema"
+                }
+            }
+        },
+        "event_element": {
+            "type": "object",
+            "properties": {
+                "subscription": {
+                    "$ref": "#/definitions/dataSchema"
+                },
+                "data": {
+                    "$ref": "#/definitions/dataSchema"
+                },
+                "cancellation": {
+                    "$ref": "#/definitions/dataSchema"
+                }
+            }
+        },
+        "dataSchema": {
+            "type": "object",
+            "if": {
+                "required": ["type"],
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "null"
+                        ]
+                    }
+                }
+            },
+            "then": {
+                "const": "td-vocab-type--DataSchema_null=pass"
+            },
+            "else": {
+                "properties": {
+                    "description": {
+                        "$ref": "#/definitions/description"
+                    },
+                    "title": {
+                        "$ref": "#/definitions/title"
+                    },
+                    "descriptions": {
+                        "$ref": "#/definitions/descriptions"
+                    },
+                    "titles": {
+                        "$ref": "#/definitions/titles"
+                    },
+                    "writeOnly": {
+                        "type": "boolean"
+                    },
+                    "readOnly": {
+                        "type": "boolean"
+                    },
+                    "oneOf": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/dataSchema"
+                        }
+                    },
+                    "unit": {
+                        "type": "string"
+                    },
+                    "enum": {
+                        "type": "array",
+                        "minItems": 1,
+                        "uniqueItems": true
+                    },
+                    "const": {},
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "boolean",
+                            "integer",
+                            "number",
+                            "string",
+                            "object",
+                            "array",
+                            "null"
+                        ]
+                    },
+                    "items": {
+                        "$ref": "#/definitions/dataSchema"
+                    },
+                    "maxItems": {
+
+                        "type": "integer",
+                        "minimum": 0
+
+                    },
+                    "minItems": {
+
+                        "type": "integer",
+                        "minimum": 0
+
+                    },
+                    "minimum": {
+                        "type": "number"
+                    },
+                    "maximum": {
+                        "type": "number"
+                    },
+                    "properties": {
+                        "additionalProperties": {
+                            "$ref": "#/definitions/dataSchema"
+                        }
+                    },
+                    "required": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "description": {
+            "type": "string"
+        },
+        "title": {
+            "type": "string"
+        },
+        "descriptions": {
+            "type": "object"
+        },
+        "titles": {
+            "type": "object"
+        },
+        "url": {
+            "type": "string",
+            "format": "uri-reference"
+        }
+    }
+}

--- a/AssertionTester/Assertions/td-vocab-type--DataSchema_number.json
+++ b/AssertionTester/Assertions/td-vocab-type--DataSchema_number.json
@@ -1,0 +1,211 @@
+{
+    "title": "td-vocab-type--DataSchema_number",
+    "description": "type: Assignment of JSON-based data types compatible with JSON Schema (one of boolean, integer, number, string, object, array, or null). MAY be included. Type: string number).",
+    "$schema ": "http://json-schema.org/draft-06/schema#",
+    "also": ["td-data-schema_type"],
+    "is-complex": true,
+    "type": "object",
+    "properties": {
+        "properties": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/property_element"
+            }
+        },
+        "actions": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/action_element"
+            }
+        },
+        "events": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/event_element"
+            }
+        }
+    },
+    "additionalProperties": true,
+    "definitions": {
+        "property_element": {
+            "type": "object",
+            "if": {
+                "required": ["type"],
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "number"
+                        ]
+                    }
+                }
+            },
+            "then": {
+                "const": "td-vocab-type--DataSchema_number=pass"
+            },
+            "else": {
+                "properties": {
+                    "uriVariables": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "$ref": "#/definitions/dataSchema"
+                        }
+                    },
+                    "oneOf": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/dataSchema"
+                        }
+                    },
+                    "items": {
+                        "$ref": "#/definitions/dataSchema"
+                    },
+                    "properties": {
+                        "additionalProperties": {
+                            "$ref": "#/definitions/dataSchema"
+                        }
+                    }
+                }
+            }
+        },
+        "action_element": {
+            "type": "object",
+            "properties": {
+                "input": {
+                    "$ref": "#/definitions/dataSchema"
+                },
+                "output": {
+                    "$ref": "#/definitions/dataSchema"
+                }
+            }
+        },
+        "event_element": {
+            "type": "object",
+            "properties": {
+                "subscription": {
+                    "$ref": "#/definitions/dataSchema"
+                },
+                "data": {
+                    "$ref": "#/definitions/dataSchema"
+                },
+                "cancellation": {
+                    "$ref": "#/definitions/dataSchema"
+                }
+            }
+        },
+        "dataSchema": {
+            "type": "object",
+            "if": {
+                "required": ["type"],
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "number"
+                        ]
+                    }
+                }
+            },
+            "then": {
+                "const": "td-vocab-type--DataSchema_number=pass"
+            },
+            "else": {
+                "properties": {
+                    "description": {
+                        "$ref": "#/definitions/description"
+                    },
+                    "title": {
+                        "$ref": "#/definitions/title"
+                    },
+                    "descriptions": {
+                        "$ref": "#/definitions/descriptions"
+                    },
+                    "titles": {
+                        "$ref": "#/definitions/titles"
+                    },
+                    "writeOnly": {
+                        "type": "boolean"
+                    },
+                    "readOnly": {
+                        "type": "boolean"
+                    },
+                    "oneOf": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/dataSchema"
+                        }
+                    },
+                    "unit": {
+                        "type": "string"
+                    },
+                    "enum": {
+                        "type": "array",
+                        "minItems": 1,
+                        "uniqueItems": true
+                    },
+                    "const": {},
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "boolean",
+                            "integer",
+                            "number",
+                            "string",
+                            "object",
+                            "array",
+                            "null"
+                        ]
+                    },
+                    "items": {
+                        "$ref": "#/definitions/dataSchema"
+                    },
+                    "maxItems": {
+
+                        "type": "integer",
+                        "minimum": 0
+
+                    },
+                    "minItems": {
+
+                        "type": "integer",
+                        "minimum": 0
+
+                    },
+                    "minimum": {
+                        "type": "number"
+                    },
+                    "maximum": {
+                        "type": "number"
+                    },
+                    "properties": {
+                        "additionalProperties": {
+                            "$ref": "#/definitions/dataSchema"
+                        }
+                    },
+                    "required": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "description": {
+            "type": "string"
+        },
+        "title": {
+            "type": "string"
+        },
+        "descriptions": {
+            "type": "object"
+        },
+        "titles": {
+            "type": "object"
+        },
+        "url": {
+            "type": "string",
+            "format": "uri-reference"
+        }
+    }
+}

--- a/AssertionTester/Assertions/td-vocab-type--DataSchema_object.json
+++ b/AssertionTester/Assertions/td-vocab-type--DataSchema_object.json
@@ -1,6 +1,6 @@
 {
-    "title": "td-vocab-type--DataSchema",
-    "description": "type: Assignment of JSON-based data types compatible with JSON Schema (one of boolean, integer, number, string, object, array, or null). MAY be included. Type: string (one of object, array, string, number, integer, boolean, or null).",
+    "title": "td-vocab-type--DataSchema_object",
+    "description": "type: Assignment of JSON-based data types compatible with JSON Schema (one of boolean, integer, number, string, object, array, or null). MAY be included. Type: string object).",
     "$schema ": "http://json-schema.org/draft-06/schema#",
     "also": ["td-data-schema_type"],
     "is-complex": true,
@@ -35,19 +35,37 @@
                     "type": {
                         "type": "string",
                         "enum": [
-                            "boolean",
-                            "integer",
-                            "number",
-                            "string",
-                            "object",
-                            "array",
-                            "null"
+                            "object"
                         ]
                     }
                 }
             },
             "then": {
-                "const": "td-vocab-type--DataSchema=pass"
+                "const": "td-vocab-type--DataSchema_object=pass"
+            },
+            "else": {
+                "properties": {
+                    "uriVariables": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "$ref": "#/definitions/dataSchema"
+                        }
+                    },
+                    "oneOf": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/dataSchema"
+                        }
+                    },
+                    "items": {
+                        "$ref": "#/definitions/dataSchema"
+                    },
+                    "properties": {
+                        "additionalProperties": {
+                            "$ref": "#/definitions/dataSchema"
+                        }
+                    }
+                }
             }
         },
         "action_element": {
@@ -83,19 +101,13 @@
                     "type": {
                         "type": "string",
                         "enum": [
-                            "boolean",
-                            "integer",
-                            "number",
-                            "string",
-                            "object",
-                            "array",
-                            "null"
+                            "object"
                         ]
                     }
                 }
             },
             "then": {
-                "const": "td-vocab-type--DataSchema=pass"
+                "const": "td-vocab-type--DataSchema_object=pass"
             },
             "else": {
                 "properties": {

--- a/AssertionTester/Assertions/td-vocab-type--DataSchema_string.json
+++ b/AssertionTester/Assertions/td-vocab-type--DataSchema_string.json
@@ -1,0 +1,211 @@
+{
+    "title": "td-vocab-type--DataSchema_string",
+    "description": "type: Assignment of JSON-based data types compatible with JSON Schema (one of boolean, integer, number, string, object, array, or null). MAY be included. Type: string string).",
+    "$schema ": "http://json-schema.org/draft-06/schema#",
+    "also": ["td-data-schema_type"],
+    "is-complex": true,
+    "type": "object",
+    "properties": {
+        "properties": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/property_element"
+            }
+        },
+        "actions": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/action_element"
+            }
+        },
+        "events": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/event_element"
+            }
+        }
+    },
+    "additionalProperties": true,
+    "definitions": {
+        "property_element": {
+            "type": "object",
+            "if": {
+                "required": ["type"],
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "string"
+                        ]
+                    }
+                }
+            },
+            "then": {
+                "const": "td-vocab-type--DataSchema_string=pass"
+            },
+            "else": {
+                "properties": {
+                    "uriVariables": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "$ref": "#/definitions/dataSchema"
+                        }
+                    },
+                    "oneOf": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/dataSchema"
+                        }
+                    },
+                    "items": {
+                        "$ref": "#/definitions/dataSchema"
+                    },
+                    "properties": {
+                        "additionalProperties": {
+                            "$ref": "#/definitions/dataSchema"
+                        }
+                    }
+                }
+            }
+        },
+        "action_element": {
+            "type": "object",
+            "properties": {
+                "input": {
+                    "$ref": "#/definitions/dataSchema"
+                },
+                "output": {
+                    "$ref": "#/definitions/dataSchema"
+                }
+            }
+        },
+        "event_element": {
+            "type": "object",
+            "properties": {
+                "subscription": {
+                    "$ref": "#/definitions/dataSchema"
+                },
+                "data": {
+                    "$ref": "#/definitions/dataSchema"
+                },
+                "cancellation": {
+                    "$ref": "#/definitions/dataSchema"
+                }
+            }
+        },
+        "dataSchema": {
+            "type": "object",
+            "if": {
+                "required": ["type"],
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "string"
+                        ]
+                    }
+                }
+            },
+            "then": {
+                "const": "td-vocab-type--DataSchema_string=pass"
+            },
+            "else": {
+                "properties": {
+                    "description": {
+                        "$ref": "#/definitions/description"
+                    },
+                    "title": {
+                        "$ref": "#/definitions/title"
+                    },
+                    "descriptions": {
+                        "$ref": "#/definitions/descriptions"
+                    },
+                    "titles": {
+                        "$ref": "#/definitions/titles"
+                    },
+                    "writeOnly": {
+                        "type": "boolean"
+                    },
+                    "readOnly": {
+                        "type": "boolean"
+                    },
+                    "oneOf": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/dataSchema"
+                        }
+                    },
+                    "unit": {
+                        "type": "string"
+                    },
+                    "enum": {
+                        "type": "array",
+                        "minItems": 1,
+                        "uniqueItems": true
+                    },
+                    "const": {},
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "boolean",
+                            "integer",
+                            "number",
+                            "string",
+                            "object",
+                            "array",
+                            "null"
+                        ]
+                    },
+                    "items": {
+                        "$ref": "#/definitions/dataSchema"
+                    },
+                    "maxItems": {
+
+                        "type": "integer",
+                        "minimum": 0
+
+                    },
+                    "minItems": {
+
+                        "type": "integer",
+                        "minimum": 0
+
+                    },
+                    "minimum": {
+                        "type": "number"
+                    },
+                    "maximum": {
+                        "type": "number"
+                    },
+                    "properties": {
+                        "additionalProperties": {
+                            "$ref": "#/definitions/dataSchema"
+                        }
+                    },
+                    "required": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "description": {
+            "type": "string"
+        },
+        "title": {
+            "type": "string"
+        },
+        "descriptions": {
+            "type": "object"
+        },
+        "titles": {
+            "type": "object"
+        },
+        "url": {
+            "type": "string",
+            "format": "uri-reference"
+        }
+    }
+}

--- a/AssertionTester/assertionTester.js
+++ b/AssertionTester/assertionTester.js
@@ -252,6 +252,7 @@ function validate(storedTdAddress, outputLocation) {
 }
 
 function toOutput(tdId) {
+    results = mergeIdenticalResults(results);
     createParents(results);
 
     // Push the non implemented assertions
@@ -314,7 +315,72 @@ function toOutput(tdId) {
             console.log("The result-" + fileName + ".csv is saved!");
         });
     }
+}
 
+function mergeIdenticalResults(resultsJSON) {
+    // first generate a list of results that appear more than once
+    // it should be a JSON object, keys are the assertion ids and the value is an array
+    // while putting these results, remove them from the results FIRST
+    // then for each key, find the resulting result: 
+    //if one fail total fail, if one pass and no fail then pass, otherwise not-impl
+
+    var identicalResults = {};
+    resultsJSON.forEach((curResult, index) => {
+        var curId = curResult.ID;
+        
+        // remove this one, but add it back if there is no duplicate
+        resultsJSON.splice(index, 1);
+        // check if there is a second one
+        const identicalIndex = resultsJSON.findIndex(x => x.ID === curId);
+        
+        if (identicalIndex > 0){ //there is a second one
+
+            // check if it already exists
+            if (identicalResults.hasOwnProperty(curId)){
+                // push if it already exists
+                identicalResults[curId].push(curResult.Status)
+            } else {
+                // create a new array with values if it does not exist
+                identicalResults[curId]=[curResult.Status]
+            }
+            // put it back such that the last identical can find its duplicate that appeared before
+            resultsJSON.unshift(curResult);
+            // process.exit();
+        } else {
+            // if there is no duplicate, put it back into results but at the beginning 
+            resultsJSON.unshift(curResult);
+        }
+    });
+
+    //get the keys to iterate through
+    var identicalKeys = Object.keys(identicalResults)
+
+    // iterate through each duplicate, calculate the new result, set the new result and then remove the duplicates 
+    identicalKeys.forEach((curKey) => {
+        var curResults = identicalResults[curKey];
+        var newResult;
+
+        if(curResults.indexOf("fail")>=0){
+            newResult="fail"
+        } else if (curResults.indexOf("pass") >= 0){
+            newResult = "pass"
+        } else {
+            newResult = "not-impl"
+        }
+        //delete each of the duplicate
+        while(resultsJSON.findIndex(x => x.ID === curKey)>=0){
+            resultsJSON.splice(resultsJSON.findIndex(x => x.ID === curKey), 1);
+        }
+
+        // push back the new result
+        resultsJSON.push({
+            "ID": curKey,
+            "Status": newResult,
+            "Comment": "result of a merge"
+        });
+
+    });
+    return resultsJSON;
 }
 
 function createParents(resultsJSON) {

--- a/AssertionTester/assertionTester.js
+++ b/AssertionTester/assertionTester.js
@@ -475,7 +475,7 @@ function checkVocabulary(tdJson) {
     ajv.addSchema(schema, 'td');
 
     var valid = ajv.validate('td', tdJson);
-    var otherAssertions = ["td-objects_securityDefinitions", "td-arrays_security", "td-vocab-security--Thing", "td-security-mandatory", "td-vocab-securityDefinitions--Thing", "td-vocab-scheme--SecurityScheme", "td-context-toplevel", "td-vocab-name--Thing", "td-vocab-security--Thing", "td-security-schemes_scheme", "td-vocab-id--Thing"];
+    var otherAssertions = ["td-objects_securityDefinitions", "td-arrays_security", "td-vocab-security--Thing", "td-security-mandatory", "td-vocab-securityDefinitions--Thing", "td-context-toplevel", "td-vocab-name--Thing", "td-vocab-security--Thing", "td-security-schemes_scheme", "td-vocab-id--Thing"];
 
     if (valid) {
         results.push({

--- a/WebContent/Examples/Valid/dataSchema.json
+++ b/WebContent/Examples/Valid/dataSchema.json
@@ -11,6 +11,12 @@
     },
     "security": ["basic_sc"],
     "properties": {
+        "status0": {
+            "type": "null",
+            "forms": [{
+                "href": "https://mylamp.example.com/status0"
+            }]
+        },
         "status": {
             "type": "number",
             "minimum": 5,

--- a/WebContent/Examples/Valid/formOpArray.json
+++ b/WebContent/Examples/Valid/formOpArray.json
@@ -29,7 +29,13 @@
                     "href": "http://example.org:9191/api/brightness/observe",
                     "op": ["observeproperty"],
                     "http:methodName": "GET",
-                    "subProtocol": "longpoll"
+                    "subProtocol": "websub"
+                },
+                {
+                    "href": "http://example.org:9191/api/brightness/unobserve",
+                    "op": ["unobserveproperty"],
+                    "http:methodName": "GET",
+                    "subProtocol": "websub"
                 }
             ]
         },

--- a/WebContent/td-schema-full.json
+++ b/WebContent/td-schema-full.json
@@ -5,7 +5,8 @@
     "type": "object",
     "properties": {
         "id": {
-            "type": "string"
+            "type": "string",
+            "format": "uri"
         },
         "name": {
             "type": "string"

--- a/WebContent/td-schema.json
+++ b/WebContent/td-schema.json
@@ -5,7 +5,8 @@
     "type": "object",
     "properties": {
         "id": {
-            "type": "string"
+            "type": "string",
+            "format": "uri"
         },
         "name": {
             "type": "string"


### PR DESCRIPTION
Now different assertion schemas can output results for same assertion id which will be then merged. 

Additionally, there are now child assertions for values that are called "one of" in the TD spec. Examples are type, scheme, subprotocol, op