### PR TITLE
Issue solving: adapt examples, check read/writeOnly

### DIFF
--- a/playground-assertions/package.json
+++ b/playground-assertions/package.json
@@ -4,7 +4,6 @@
   "license": "EPL-2.0 OR W3C-20150513",
   "version": "1.0.0",
   "description": "TBD",
-  "private": true,
   "main": "index.js",
   "scripts": {
     "test": "node test.js",

--- a/playground-cli/package.json
+++ b/playground-cli/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
-  "private": true,
   "scripts": {
     "test": "node ./index.js",
     "start": "node ./index.js"

--- a/playground-core/examples/tds/valid/formOpArrayWithDefaults.json
+++ b/playground-core/examples/tds/valid/formOpArrayWithDefaults.json
@@ -1,0 +1,157 @@
+{
+    "id": "urn:formOpArray",
+    "@context":"https://www.w3.org/2019/wot/td/v1",
+    "title": "MyLampThing",
+    "description": "Valid TD demonstrating how to use multiple forms with different op",
+    "securityDefinitions": {
+        "basic_sc": {
+            "scheme": "basic",
+            "in": "header"
+        }
+    },
+    "security": ["basic_sc"],
+    "properties": {
+        "brightness": {
+            "description": "The current brightness setting",
+            "type": "integer",
+            "minimum": -64,
+            "maximum": 64,
+            "observable": true,
+            "forms": [{
+                    "href": "http://example.org:9191/api/brightness",
+                    "op": ["readproperty"],
+                    "contentType": "application/json"
+                },
+                {
+                    "href": "http://example.org:9191/api/brightness",
+                    "op": ["writeproperty"],
+                    "http:methodName": "POST",
+                    "contentType": "application/json"
+                },
+                {
+                    "href": "http://example.org:9191/api/brightness/observe",
+                    "op": ["observeproperty"],
+                    "http:methodName": "GET",
+                    "subProtocol": "websub",
+                    "contentType": "application/json"
+                },
+                {
+                    "href": "http://example.org:9191/api/brightness/unobserve",
+                    "op": ["unobserveproperty"],
+                    "http:methodName": "GET",
+                    "subProtocol": "websub",
+                    "contentType": "application/json"
+                }
+            ]
+        },
+        "simple": {
+            "forms": [{
+                "href": "http://example.org:9191/api/simple1",
+                "contentType": "application/json",
+                "op": "readproperty"
+            }]
+        },
+        "simple2": {
+            "forms": [{
+                    "href": "http://example.org:9191/api/simple2",
+                    "op": ["readproperty"],
+                    "contentType": "application/json"
+                },
+                {
+                    "href": "http://example.org:9191/api/simple2",
+                    "http:methodName": "POST",
+                    "contentType": "application/json",
+                    "op": "writeproperty"
+                },
+                {
+                    "href": "http://example.org:9191/api/simple2/observe",
+                    "op": ["observeproperty"],
+                    "http:methodName": "GET",
+                    "subProtocol": "longpoll",
+                    "contentType": "application/json"
+                }
+            ]
+        }
+
+    },
+    "actions": {
+        "toggle": {
+            "safe": false,
+            "idempotent": false,
+            "forms": [{
+                "href": "https://mylamp.example.com/toggle",
+                "op": ["invokeaction"],
+                "contentType": "application/json"
+            }]
+        },
+        "simple3": {
+            "safe": false,
+            "idempotent": false,
+            "forms": [{
+                "href": "https://mylamp.example.com/toggle",
+                "contentType": "application/json",
+                "op": "invokeaction"
+            }]
+        },
+        "simple4": {
+            "safe": false,
+            "idempotent": false,
+            "forms": [{
+                    "href": "https://mylamp.example.com/toggle",
+                    "op": ["invokeaction"],
+                    "contentType": "application/json"
+                },
+                {
+                    "href": "https://mylamp.example.com/toggle",
+                    "contentType": "application/json",
+                    "op": "invokeaction"
+                }
+            ]
+        }
+    },
+    "events": {
+        "overheating": {
+            "data": {
+                "type": "string"
+            },
+            "forms": [{
+                "href": "https://mylamp.example.com/oh",
+                "subProtocol": "longpoll",
+                "op": ["subscribeevent"],
+                "contentType": "application/json"
+            }]
+        },
+        "simple5": {
+            "forms": [{
+                "href": "https://mylamp.example.com/oh",
+                "subProtocol": "longpoll",
+                "contentType": "application/json",
+                "op": "subscribeevent"
+            }]
+        },
+        "simple6": {
+            "data": {
+                "type": "string"
+            },
+            "forms": [{
+                    "href": "https://mylamp.example.com/oh",
+                    "subProtocol": "longpoll",
+                    "op": ["subscribeevent"],
+                    "contentType": "application/json"
+                },
+                {
+                    "href": "https://mylamp.example.com/oh",
+                    "subProtocol": "longpoll",
+                    "op": ["unsubscribeevent"],
+                    "contentType": "application/json"
+                },
+                {
+                    "href": "https://mylamp.example.com/oh",
+                    "subProtocol": "longpoll",
+                    "contentType": "application/json",
+                    "op": "subscribeevent"
+                }
+            ]
+        }
+    }
+}

--- a/playground-core/examples/tds/valid/simpleWithDefaults.json
+++ b/playground-core/examples/tds/valid/simpleWithDefaults.json
@@ -1,0 +1,44 @@
+{
+    "id": "urn:simple",
+    "@context":"https://www.w3.org/2019/wot/td/v1",
+    "title": "MyLampThing",
+    "description":"Valid TD copied from the spec's first example",
+    "securityDefinitions": {
+        "basic_sc": {"scheme": "basic","in":"header"}
+    },
+    "security": ["basic_sc"],
+    "properties": {
+        "status" : {
+            "type": "string",
+            "forms": [
+                {
+                    "href": "https://mylamp.example.com/status",
+                    "op": "readproperty",
+                    "contentType": "application/json"
+                }
+                ]
+        }
+    },
+    "actions": {
+        "toggle" : {
+            "safe": false,
+            "idempotent": false,
+            "forms": [{
+                        "href": "https://mylamp.example.com/toggle",
+                        "op": "invokeaction",
+                        "contentType": "application/json"
+                        }]
+        }
+    },
+    "events":{
+        "overheating":{
+            "data": {"type": "string"},
+            "forms": [{
+                "href": "https://mylamp.example.com/oh",
+                "op": "subscribeevent",
+                "subprotocol": "longpoll",
+                "contentType": "application/json"
+            }]
+        }
+    }
+}

--- a/playground-core/index.js
+++ b/playground-core/index.js
@@ -380,6 +380,13 @@ function tdValidator(tdString, logFunc, { checkDefaults=true, checkJsonLd=true }
                                             logFunc('! Warning: In property ' + curPropertyName + " in forms[" + formElIndex +
                                             '], writeOnly is set but the op property contains "readproperty"')
                                         }
+                                        else if ((typeof formEl.op === "string" && formEl.op === "observeproperty") ||
+                                                 (typeof formEl.op === "object" && formEl.op.some( el => (el === "observeproperty"))))
+                                                 {
+                                                    details.readWriteOnly = "warning"
+                                                    logFunc('! Warning: In property ' + curPropertyName + " in forms[" + formElIndex +
+                                                    '], writeOnly is set but the op property contains "observeproperty"')
+                                                 }
                                     }
                                     else {
                                         details.readWriteOnly = "warning"
@@ -388,6 +395,13 @@ function tdValidator(tdString, logFunc, { checkDefaults=true, checkJsonLd=true }
                                     }
                                 }
                             }
+                        }
+
+                        // check if observable is also set
+                        if (curProperty.hasOwnProperty("observable") && curProperty.observable === true) {
+                            details.readWriteOnly = "warning"
+                            logFunc('! Warning: In property ' + curPropertyName +
+                                ', both writeOnly and observable are set true!')
                         }
                     }
                 }

--- a/playground-core/index.js
+++ b/playground-core/index.js
@@ -337,7 +337,7 @@ function tdValidator(tdString, logFunc, { checkDefaults=true, checkJsonLd=true }
                         if (curProperty.hasOwnProperty("writeOnly") && curProperty.writeOnly === true) {
                             details.readWriteOnly = "warning"
                             logFunc('! Warning: In property ' + curPropertyName +
-                                ', both readOnly and writeOnly are set true!')
+                                ', both readOnly and writeOnly are set to true!')
                         }
 
                         // check forms if op writeProperty is set
@@ -401,7 +401,7 @@ function tdValidator(tdString, logFunc, { checkDefaults=true, checkJsonLd=true }
                         if (curProperty.hasOwnProperty("observable") && curProperty.observable === true) {
                             details.readWriteOnly = "warning"
                             logFunc('! Warning: In property ' + curPropertyName +
-                                ', both writeOnly and observable are set true!')
+                                ', both writeOnly and observable are set to true!')
                         }
                     }
                 }

--- a/playground-core/package.json
+++ b/playground-core/package.json
@@ -4,7 +4,6 @@
   "license": "EPL-2.0 OR W3C-20150513",
   "version": "1.0.0",
   "description": "TBD",
-  "private": true,
   "main": "index.js",
   "scripts": {
     "test": "node test.js",

--- a/playground-web/package.json
+++ b/playground-web/package.json
@@ -1,7 +1,6 @@
 {
   "name": "playground-web",
   "version": "1.0.0",
-  "private": true,
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/playground-web/util.js
+++ b/playground-web/util.js
@@ -224,13 +224,21 @@ function hideValidationStatusTable() {
  */
 export function getExamplesList(){
             const examples={
+                "SimpleTDWithDefaults": {
+                    "addr": "./node_modules/playground-core/examples/tds/valid/simpleWithDefaults.json",
+                    "type": "valid"
+                },
+                "MultipleOpWithDefaults":{
+                    "addr":"./node_modules/playground-core/examples/tds/valid/formOpArrayWithDefaults.json",
+                    "type":"valid"
+                },
                 "SimpleTD": {
                     "addr": "./node_modules/playground-core/examples/tds/valid/simple.json",
-                    "type": "valid"
+                    "type": "warning"
                 },
                 "MultipleOp":{
                     "addr":"./node_modules/playground-core/examples/tds/valid/formOpArray.json",
-                    "type":"valid"
+                    "type":"warning"
                 },
                 "EnumConstContradiction":{
                     "addr":"./node_modules/playground-core/examples/tds/warning/enumConst.json",


### PR DESCRIPTION
# Changes
* Added two new examples (former green colored examples enhanced with default values to really pass all validations)
* Changed classification of former valid examples to warning
* Removed `private: true` tag from package infos to prepare publication
* Added additional check for read/writeOnly:
  * Warning if `readOnly` and `writeOnly` are true
  * Warning if `writeOnly` and `observable` are true
  * Warning if `writeOnly` or `readOnly` is true and `op` not set (--> default is `["readproperty", "writeproperty"]`)
  * Warning if `writeOnly` or `readOnly` is set and `readproperty` or `writeproperty` contained in `op` array or is the `op` string value

# Solves
* #130
* #117 
* #116  
