### PR TITLE
add symbols for example categories

### DIFF
--- a/playground-web/util.js
+++ b/playground-web/util.js
@@ -55,13 +55,13 @@ export function populateExamples(urlAddrObject){
     Object.keys(urlAddrObject).forEach( name => {
         const data = urlAddrObject[name]
         if (data.type === "valid") {
-            examplesHtml+='<option class="btn-success" value='+name+'>'+name +'</option>';
+            examplesHtml+='<option class="btn-success" value=' + name + '>' + name + ' &check;</option>';
         }
 		if (data.type === "warning") {
-            examplesHtml+='<option class="btn-warning" value='+name+'>'+name +'</option>';
+            examplesHtml+='<option class="btn-warning" value=' + name + '>' + name + ' !</option>';
         }
 		if (data.type === "invalid"){
-			examplesHtml+='<option class="btn-danger" value='+name+'>'+name +'</option>';
+			examplesHtml+='<option class="btn-danger" value=' +name + '>' + name + ' &cross;</option>';
         }
     })
 


### PR DESCRIPTION
Add the following symbols to the example list, to make their validation results known, even if the background color styling does not work for the respective OS/Browser pair. 
valid -> &check;
warning -> !
fail -> &cross;

Solves #129 

Looks like this:

![grafik](https://user-images.githubusercontent.com/55034043/92390234-c2ed5980-f11a-11ea-841d-9e7aec9b8942.png)
on Chrome, Windows Firefox
![grafik](https://user-images.githubusercontent.com/55034043/92394825-858cca00-f122-11ea-85d7-a3b1896ce703.png)
on Linux Firefox and maybe also other browsers
