### PR TITLE
Move gist backend CI to separate job

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -30,8 +30,8 @@ jobs:
         run: lerna run test --no-bail --stream
         env:
           # avoid errors from gist_backend test
-          TD_PLAYGROUND_LOGIN: ${{ secrets.TD_PLAYGROUND_LOGIN }}
-          TD_PLAYGROUND_TOKEN: ${{ secrets.TD_PLAYGROUND_TOKEN }}
+          TD_PLAYGROUND_LOGIN: ${{ example }}
+          TD_PLAYGROUND_TOKEN: ${{ example }}
 
   deploy-via-ssh:
 

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -30,8 +30,8 @@ jobs:
         run: lerna run test --no-bail --stream
         env:
           # avoid errors from gist_backend test
-          TD_PLAYGROUND_LOGIN: ${{ example }}
-          TD_PLAYGROUND_TOKEN: ${{ example }}
+          TD_PLAYGROUND_LOGIN: exampleString
+          TD_PLAYGROUND_TOKEN: exampleString
 
   deploy-via-ssh:
 

--- a/.github/workflows/gist-backend-ci.yaml
+++ b/.github/workflows/gist-backend-ci.yaml
@@ -1,0 +1,33 @@
+name: Gist Backend CI
+
+on: push
+
+jobs:
+
+  test-gist-backend:
+
+    runs-on: ubuntu-latest
+
+    # make sure repository secrets are set
+    if: ${{ github.event_name == 'push' && github.repository_owner == 'thingweb' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Use Node.js 12.x
+        uses: actions/setup-node@v1
+        with:
+            node-version: 12.x
+      
+      - name: Install deps
+        run: |
+          cd ./packages/gist_backend
+          npm install
+      
+      - name: Run real Test
+        run: npm run realTest
+        env:
+          # set real credentials
+          TD_PLAYGROUND_LOGIN: ${{ secrets.TD_PLAYGROUND_LOGIN }}
+          TD_PLAYGROUND_TOKEN: ${{ secrets.TD_PLAYGROUND_TOKEN }}

--- a/packages/gist_backend/README.md
+++ b/packages/gist_backend/README.md
@@ -3,7 +3,8 @@
 The backend to submit gists to GitHub while keeping authorization private.
 
 Before starting this backend please set the TD_PLAYGROUND_LOGIN and TD_PLAYGROUND_TOKEN environment variables on your system to your GitHub access credentials.
+For testing purposes (to see if npm test succeeds) setting empty Variables is sufficient, to pass the `npm run realTest` command your credentials have to be valid.
 
-## License 
+## License
 
 Licensed under the MIT license, see [License](./LICENSE.md).

--- a/packages/gist_backend/package.json
+++ b/packages/gist_backend/package.json
@@ -16,7 +16,8 @@
   },
   "scripts": {
     "test": "node test.js",
-    "start": "node server.js"
+    "start": "node server.js",
+    "realTest": "node real-test.js"
   },
   "dependencies": {
     "express": "^4.17.1",

--- a/packages/gist_backend/real-test.js
+++ b/packages/gist_backend/real-test.js
@@ -1,0 +1,94 @@
+/**
+ * @file launches the gist submission backend
+ *       waits so the server is ready
+ *       sends a TD to submit
+ *       deletes the submitted TD by an own request
+ *       directly to GitHub
+ */
+
+const {spawn} = require("child_process")
+const { port, login, token } = require("./config")
+const fetch = require("node-fetch")
+
+// start server and handle process events
+const startedServer = spawn("node", ["server.js"])
+startedServer.stdout.on("data", sOut => {
+    console.log("stdout: " + sOut)
+})
+startedServer.stderr.on("data", sErr => {
+    if (sErr !== "") {
+        console.error("stderr: " + sErr)
+        process.exit(1)
+    }
+})
+startedServer.on("error", err => {
+    console.error("failed to start server: ", err)
+    process.exit(1)
+})
+startedServer.on("close", code => {
+    if (code !== null) {
+        console.error("Server exited with code: " + code)
+        process.exit(1)
+    }
+    else {
+        console.log("Server shutdown was fine")
+    }
+})
+
+// wait until server is up and running, then make request
+setTimeout( createGist, 3000)
+
+function createGist() {
+    // Make the gist submission request
+    fetch("http://localhost:" + port, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json"
+        },
+        body: JSON.stringify({
+            name: "CI gist_backend test 2",
+            description: "An TD submitted to test if the backend works, should be removed soon...",
+            content: "{\n  \"id\": \"test:test:test\"\n}"
+        })
+    }).then( reply => {
+        if (reply.status === 201) {
+            reply.json()
+            .then(json => {
+                // res({htmlUrl: json.html_url, location: json.url})
+                console.log("Gist submission successful! starting delete")
+                console.log(json)
+                startedServer.kill()
+                deleteGist(json.location)
+            }, err => {
+                console.error("The gist reply could not be turned into JSON: " + err)
+                process.exit(1)
+            })
+        } else {
+            console.error("The gist could not be created by GitHub: " + reply.status + " " + reply.statusText)
+            process.exit(1)
+        }
+    }, err => {
+        console.error("Gist request at GitHub failed: " + err)
+        process.exit(1)
+    })
+}
+
+function deleteGist(gistLocation) {
+    fetch(gistLocation, {
+        method: "DELETE",
+        headers: {
+            Authorization: "Basic " + Buffer.from(login + ":" + token).toString("base64")
+        }
+    }).then( reply => {
+        if (reply.status === 204) {
+            console.log("gist deletion worked")
+        }
+        else {
+            console.error("There has been a problem deleting the gist:" + reply.status + " " + reply.statusText)
+            process.exit(1)
+        }
+    }, err => {
+        console.error("The gist delete request at GitHub failed: " + err)
+        process.exit(1)
+    })
+}

--- a/packages/gist_backend/test.js
+++ b/packages/gist_backend/test.js
@@ -1,14 +1,14 @@
 /**
  * @file launches the gist submission backend
- *       waits so the server is ready
- *       sends a TD to submit
- *       deletes the submitted TD by an own request
- *       directly to GitHub
+ *       waits until the server is ready and
+ *       throws an error if there is a problem
+ *       starting the backend
+ *       (this test does not require credentials
+ *        just empty env-Vars, for the server not
+ *        to fail)
  */
 
 const {spawn} = require("child_process")
-const { port, login, token } = require("./config")
-const fetch = require("node-fetch")
 
 // start server and handle process events
 const startedServer = spawn("node", ["server.js"])
@@ -35,60 +35,5 @@ startedServer.on("close", code => {
     }
 })
 
-// wait until server is up and running, then make request
-setTimeout( createGist, 3000)
-
-function createGist() {
-    // Make the gist submission request
-    fetch("http://localhost:" + port, {
-        method: "POST",
-        headers: {
-            "Content-Type": "application/json"
-        },
-        body: JSON.stringify({
-            name: "CI gist_backend test 2",
-            description: "An TD submitted to test if the backend works, should be removed soon...",
-            content: "{\n  \"id\": \"test:test:test\"\n}"
-        })
-    }).then( reply => {
-        if (reply.status === 201) {
-            reply.json()
-            .then(json => {
-                // res({htmlUrl: json.html_url, location: json.url})
-                console.log("Gist submission successful! starting delete")
-                console.log(json)
-                startedServer.kill()
-                deleteGist(json.location)
-            }, err => {
-                console.error("The gist reply could not be turned into JSON: " + err)
-                process.exit(1)
-            })
-        } else {
-            console.error("The gist could not be created by GitHub: " + reply.status + " " + reply.statusText)
-            process.exit(1)
-        }
-    }, err => {
-        console.error("Gist request at GitHub failed: " + err)
-        process.exit(1)
-    })
-}
-
-function deleteGist(gistLocation) {
-    fetch(gistLocation, {
-        method: "DELETE",
-        headers: {
-            Authorization: "Basic " + Buffer.from(login + ":" + token).toString("base64")
-        }
-    }).then( reply => {
-        if (reply.status === 204) {
-            console.log("gist deletion worked")
-        }
-        else {
-            console.error("There has been a problem deleting the gist:" + reply.status + " " + reply.statusText)
-            process.exit(1)
-        }
-    }, err => {
-        console.error("The gist delete request at GitHub failed: " + err)
-        process.exit(1)
-    })
-}
+// wait until server is up and running, then shut it back down
+setTimeout(()=>{startedServer.kill()}, 3000)


### PR DESCRIPTION
Only trigger testing the gist_backend by really submitting a TD gist (and delete it afterwards) on pushes to the `thingweb/thingweb-playground` repository.

For default CI simply start the backend server and shut it back down if it doesn't throw an error.