### PR TITLE
Allow for assertion testing of TMs without id and title

### DIFF
--- a/packages/assertions/index.js
+++ b/packages/assertions/index.js
@@ -157,13 +157,16 @@ function tdAssertions(tdStrings, fileLoader, logFunc, givenManual, doneEventEmit
             const jsonResults = {}
             tmStrings.forEach( tmToValidate => {
                 // check if id exists, use it for name if it does, title + some rand number otherwise
-                let tmName = ""
-                if ("id" in JSON.parse(tmToValidate)){
-                    const tmId = JSON.parse(tmToValidate).id
+                const parsedTm = JSON.parse(tmToValidate)
+                const generateNumber = () => Math.floor(Math.random() * 1000)
+                let tmName
+                if ("id" in parsedTm){
+                    const tmId = parsedTm.id
                     tmName = tmId.replace(/:/g, "_")
+                } else if ("title" in parsedTm) {
+                    tmName = parsedTm.title + generateNumber()
                 } else {
-                    const tmTitle = JSON.parse(tmToValidate).title
-                    tmName = tmTitle + Math.floor(Math.random() * 1000)
+                    tmName = `Unnamed TM ${generateNumber()}`
                 }
                 if(doneEventEmitter) doneEventEmitter.emit("start", tmName)
 


### PR DESCRIPTION
This PR fixes an issue discovered in https://github.com/w3c/wot-testing/pull/349: In TMs, both the `title` and the `id` fields are optional. This led to problems with the way a `tmName` was generated before, as an `undefined` title could be concatenated with the random number that is being generated, creating a `NaN` value in the process.

The PR solves this problem by introducing an additional check for the title. If the title should be `undefined`, then an `Unnamed TM ` string is used instead. I also applied some minor refactoring in order to avoid too much code duplication.

An alternative would be to generate a UUID for the `tmName` instead, as this would minimize the potential for name clashes. However, this could also be done in a follow-up PR if deemed useful.