### PR TITLE
Update to newer node versions for ci

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 15.x]
+        node-version: [12.x, 16.x, 18.x]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
We keep 12.x since the Eclipse server where the web interface is deployed runs 12