### PR TITLE
Change $defs to definitions

### DIFF
--- a/packages/assertions/assertions-td/sec-body-name-json-pointer copy.json
+++ b/packages/assertions/assertions-td/sec-body-name-json-pointer copy.json
@@ -9,7 +9,7 @@
             "type": "object",
             "minProperties": 1,
             "additionalProperties": {
-                "$ref": "#/$defs/securityScheme"
+                "$ref": "#/definitions/securityScheme"
             }
         }
     },
@@ -17,7 +17,7 @@
         "securityDefinitions"
     ],
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "securityScheme": {
             "if": {
                 "type": "object",

--- a/packages/assertions/assertions-td/sec-body-name-json-pointer.json
+++ b/packages/assertions/assertions-td/sec-body-name-json-pointer.json
@@ -9,7 +9,7 @@
             "type": "object",
             "minProperties": 1,
             "additionalProperties": {
-                "$ref": "#/$defs/securityScheme"
+                "$ref": "#/definitions/securityScheme"
             }
         }
     },
@@ -17,7 +17,7 @@
         "securityDefinitions"
     ],
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "securityScheme": {
             "if": {
                 "type": "object",

--- a/packages/assertions/assertions-td/td-action-arrays.json
+++ b/packages/assertions/assertions-td/td-action-arrays.json
@@ -8,7 +8,7 @@
     "properties": {
         "actions": {
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         }
     },
@@ -16,14 +16,14 @@
         "actions"
     ],
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "action_element": {
             "type": "object",
             "properties": {
                 "forms": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/$defs/form_element"
+                        "$ref": "#/definitions/form_element"
                     }
                 }
 
@@ -37,7 +37,7 @@
             "type": "object",
             "properties": {
                 "href": {
-                    "$ref": "#/$defs/url"
+                    "$ref": "#/definitions/url"
                 },
                 "op": {
                     "oneOf": [{

--- a/packages/assertions/assertions-td/td-action-names_at-type.json
+++ b/packages/assertions/assertions-td/td-action-names_at-type.json
@@ -7,12 +7,12 @@
     "properties": {
         "actions": {
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "action_element": {
             "if": {
                 "type": "object",

--- a/packages/assertions/assertions-td/td-action-names_description.json
+++ b/packages/assertions/assertions-td/td-action-names_description.json
@@ -7,12 +7,12 @@
     "properties": {
         "actions": {
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "action_element": {
             "if": {
                 "type": "object",

--- a/packages/assertions/assertions-td/td-action-names_descriptions.json
+++ b/packages/assertions/assertions-td/td-action-names_descriptions.json
@@ -8,12 +8,12 @@
     "properties": {
         "actions": {
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "action_element": {
             "if": {
                 "type": "object",

--- a/packages/assertions/assertions-td/td-action-names_title.json
+++ b/packages/assertions/assertions-td/td-action-names_title.json
@@ -7,12 +7,12 @@
     "properties": {
         "actions": {
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "action_element": {
             "if": {
                 "type": "object",

--- a/packages/assertions/assertions-td/td-action-names_titles.json
+++ b/packages/assertions/assertions-td/td-action-names_titles.json
@@ -7,12 +7,12 @@
     "properties": {
         "actions": {
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "action_element": {
             "if": {
                 "type": "object",

--- a/packages/assertions/assertions-td/td-action-names_uriVariables.json
+++ b/packages/assertions/assertions-td/td-action-names_uriVariables.json
@@ -7,12 +7,12 @@
     "properties": {
         "actions": {
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "action_element": {
             "if": {
                 "type": "object",

--- a/packages/assertions/assertions-td/td-context-default-language.json
+++ b/packages/assertions/assertions-td/td-context-default-language.json
@@ -20,7 +20,7 @@
                 },
                 "else": {
                     "if": {
-                        "$ref": "#/$defs/thing-context"
+                        "$ref": "#/definitions/thing-context"
                     },
                     "then": {
                         "const": "td-context-default-language=pass"
@@ -30,7 +30,7 @@
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "thing-context-w3c-uri": {
             "type": "string",
             "enum": [
@@ -41,7 +41,7 @@
             "type": "array",
             "items": [
                 {
-                    "$ref": "#/$defs/thing-context-w3c-uri"
+                    "$ref": "#/definitions/thing-context-w3c-uri"
                 }
             ],
             "additionalItems": {

--- a/packages/assertions/assertions-td/td-context-ns-td10-namespace.json
+++ b/packages/assertions/assertions-td/td-context-ns-td10-namespace.json
@@ -10,7 +10,7 @@
     ],
     "properties": {
       "@context": {
-        "$ref": "#/$defs/thing-context"
+        "$ref": "#/definitions/thing-context"
       }
     }
   },
@@ -18,7 +18,7 @@
     "const": "td-context-ns-td10-namespace=pass"
   },
   "additionalProperties": true,
-  "$defs": {
+  "definitions": {
     "thing-context-td-uri-v1": {
       "type": "string",
       "const": "https://www.w3.org/2019/wot/td/v1"
@@ -32,10 +32,10 @@
       "type": "array",
       "prefixItems": [
         {
-          "$ref": "$defs/thing-context-td-uri-v1"
+          "$ref": "definitions/thing-context-td-uri-v1"
         },
         {
-          "$ref": "$defs/thing-context-td-uri-v1.1"
+          "$ref": "definitions/thing-context-td-uri-v1.1"
         }
       ],
       "contains": {
@@ -46,7 +46,7 @@
       "additionalItems": {
         "anyOf": [
           {
-            "$ref": "$defs/anyUri"
+            "$ref": "definitions/anyUri"
           },
           {
             "type": "object"

--- a/packages/assertions/assertions-td/td-context-ns-thing-map-of-namespaces.json
+++ b/packages/assertions/assertions-td/td-context-ns-thing-map-of-namespaces.json
@@ -20,7 +20,7 @@
                 },
                 "else": {
                     "if": {
-                        "$ref": "#/$defs/thing-context"
+                        "$ref": "#/definitions/thing-context"
                     },
                     "then": {
                         "const": "td-context-ns-thing-map-of-namespaces=pass"
@@ -30,7 +30,7 @@
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "thing-context-w3c-uri": {
             "type": "string",
             "enum": [
@@ -41,7 +41,7 @@
             "type": "array",
             "items": [
                 {
-                    "$ref": "#/$defs/thing-context-w3c-uri"
+                    "$ref": "#/definitions/thing-context-w3c-uri"
                 }
             ],
             "additionalItems": {

--- a/packages/assertions/assertions-td/td-context-ns-thing-optional.json
+++ b/packages/assertions/assertions-td/td-context-ns-thing-optional.json
@@ -20,7 +20,7 @@
                 },
                 "else": {
                     "if": {
-                        "$ref": "#/$defs/thing-context"
+                        "$ref": "#/definitions/thing-context"
                     },
                     "then": {
                         "const": "td-context-ns-thing-optional=pass"
@@ -30,7 +30,7 @@
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "thing-context-w3c-uri": {
             "type": "string",
             "enum": [
@@ -41,11 +41,11 @@
             "oneOf": [{
                     "type": "array",
                     "items": [{
-                        "$ref": "#/$defs/thing-context-w3c-uri"
+                        "$ref": "#/definitions/thing-context-w3c-uri"
                     }],
                     "additionalItems": {
                         "anyOf": [{
-                                "$ref": "#/$defs/anyUri"
+                                "$ref": "#/definitions/anyUri"
                             },
                             {
                                 "type": "object"
@@ -54,7 +54,7 @@
                     }
                 },
                 {
-                    "$ref": "#/$defs/thing-context-w3c-uri"
+                    "$ref": "#/definitions/thing-context-w3c-uri"
                 }
             ]
         },

--- a/packages/assertions/assertions-td/td-context.json
+++ b/packages/assertions/assertions-td/td-context.json
@@ -13,7 +13,7 @@
         ],
         "properties": {
             "@context": {
-                "$ref": "#/$defs/thing-context"
+                "$ref": "#/definitions/thing-context"
             }
         }
     },
@@ -21,7 +21,7 @@
         "const": "td-context=pass"
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "thing-context-w3c-uri": {
             "type": "string",
             "enum": [
@@ -34,13 +34,13 @@
                     "type": "array",
                     "items": [
                         {
-                            "$ref": "#/$defs/thing-context-w3c-uri"
+                            "$ref": "#/definitions/thing-context-w3c-uri"
                         }
                     ],
                     "additionalItems": {
                         "anyOf": [
                             {
-                                "$ref": "#/$defs/anyUri"
+                                "$ref": "#/definitions/anyUri"
                             },
                             {
                                 "type": "object"
@@ -49,7 +49,7 @@
                     }
                 },
                 {
-                    "$ref": "#/$defs/thing-context-w3c-uri"
+                    "$ref": "#/definitions/thing-context-w3c-uri"
                 }
             ]
         },

--- a/packages/assertions/assertions-td/td-event-arrays.json
+++ b/packages/assertions/assertions-td/td-event-arrays.json
@@ -8,7 +8,7 @@
     "properties": {
         "events": {
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
@@ -16,14 +16,14 @@
         "events"
     ],
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "event_element": {
             "type": "object",
             "properties": {
                 "forms": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/$defs/form_element"
+                        "$ref": "#/definitions/form_element"
                     }
                 }
             },
@@ -36,7 +36,7 @@
             "type": "object",
             "properties": {
                 "href": {
-                    "$ref": "#/$defs/url"
+                    "$ref": "#/definitions/url"
                 },
                 "op": {
                     "oneOf": [{

--- a/packages/assertions/assertions-td/td-event-names_at-type.json
+++ b/packages/assertions/assertions-td/td-event-names_at-type.json
@@ -7,12 +7,12 @@
     "properties": {
         "events": {
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "event_element": {
             "type": "object",
             "if": {

--- a/packages/assertions/assertions-td/td-event-names_description.json
+++ b/packages/assertions/assertions-td/td-event-names_description.json
@@ -7,12 +7,12 @@
     "properties": {
         "events": {
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "event_element": {
             "type": "object",
             "if": {

--- a/packages/assertions/assertions-td/td-event-names_descriptions.json
+++ b/packages/assertions/assertions-td/td-event-names_descriptions.json
@@ -8,12 +8,12 @@
     "properties": {
         "events": {
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "event_element": {
             "type": "object",
             "if": {

--- a/packages/assertions/assertions-td/td-event-names_title.json
+++ b/packages/assertions/assertions-td/td-event-names_title.json
@@ -7,12 +7,12 @@
     "properties": {
         "events": {
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "event_element": {
             "type": "object",
             "if": {

--- a/packages/assertions/assertions-td/td-event-names_titles.json
+++ b/packages/assertions/assertions-td/td-event-names_titles.json
@@ -7,12 +7,12 @@
     "properties": {
         "events": {
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "event_element": {
             "type": "object",
             "if": {

--- a/packages/assertions/assertions-td/td-event-names_uriVariables.json
+++ b/packages/assertions/assertions-td/td-event-names_uriVariables.json
@@ -7,12 +7,12 @@
     "properties": {
         "events": {
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "event_element": {
             "type": "object",
             "if": {

--- a/packages/assertions/assertions-td/td-integer-type.json
+++ b/packages/assertions/assertions-td/td-integer-type.json
@@ -8,24 +8,24 @@
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {
@@ -46,29 +46,29 @@
                 "properties": {
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "uriVariables": {
                         "type": "object",
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -80,10 +80,10 @@
             "type": "object",
             "properties": {
                 "input": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "output": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -91,13 +91,13 @@
             "type": "object",
             "properties": {
                 "subscription": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "data": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "cancellation": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -120,16 +120,16 @@
             "else": {
                 "properties": {
                     "description": {
-                        "$ref": "#/$defs/description"
+                        "$ref": "#/definitions/description"
                     },
                     "title": {
-                        "$ref": "#/$defs/title"
+                        "$ref": "#/definitions/title"
                     },
                     "descriptions": {
-                        "$ref": "#/$defs/descriptions"
+                        "$ref": "#/definitions/descriptions"
                     },
                     "titles": {
-                        "$ref": "#/$defs/titles"
+                        "$ref": "#/definitions/titles"
                     },
                     "writeOnly": {
                         "type": "boolean"
@@ -140,7 +140,7 @@
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "unit": {
@@ -166,12 +166,12 @@
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -196,7 +196,7 @@
                     },
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "required": {

--- a/packages/assertions/assertions-td/td-links.json
+++ b/packages/assertions/assertions-td/td-links.json
@@ -9,7 +9,7 @@
         "links": {
             "type": "array",
             "items": {
-                "$ref": "#/$defs/link_element"
+                "$ref": "#/definitions/link_element"
             }
         }
     },
@@ -17,15 +17,15 @@
         "links"
     ],
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "link_element": {
             "type": "object",
             "properties": {
                 "anchor": {
-                    "$ref": "#/$defs/url"
+                    "$ref": "#/definitions/url"
                 },
                 "href": {
-                    "$ref": "#/$defs/url"
+                    "$ref": "#/definitions/url"
                 },
                 "rel": {
                     "type": "string"

--- a/packages/assertions/assertions-td/td-number-type.json
+++ b/packages/assertions/assertions-td/td-number-type.json
@@ -8,24 +8,24 @@
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {
@@ -46,29 +46,29 @@
                 "properties": {
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "uriVariables": {
                         "type": "object",
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -80,10 +80,10 @@
             "type": "object",
             "properties": {
                 "input": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "output": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -91,13 +91,13 @@
             "type": "object",
             "properties": {
                 "subscription": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "data": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "cancellation": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -120,16 +120,16 @@
             "else": {
                 "properties": {
                     "description": {
-                        "$ref": "#/$defs/description"
+                        "$ref": "#/definitions/description"
                     },
                     "title": {
-                        "$ref": "#/$defs/title"
+                        "$ref": "#/definitions/title"
                     },
                     "descriptions": {
-                        "$ref": "#/$defs/descriptions"
+                        "$ref": "#/definitions/descriptions"
                     },
                     "titles": {
-                        "$ref": "#/$defs/titles"
+                        "$ref": "#/definitions/titles"
                     },
                     "writeOnly": {
                         "type": "boolean"
@@ -140,7 +140,7 @@
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "unit": {
@@ -166,12 +166,12 @@
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -196,7 +196,7 @@
                     },
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "required": {

--- a/packages/assertions/assertions-td/td-op-for-action.json
+++ b/packages/assertions/assertions-td/td-op-for-action.json
@@ -8,12 +8,12 @@
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "action_element": {
             "type": "object",
             "properties": {
@@ -21,7 +21,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element_action"
+                        "$ref": "#/definitions/form_element_action"
                     }
                 }
             },
@@ -35,7 +35,7 @@
                 "type": "object",
                 "properties": {
                     "href": {
-                        "$ref": "#/$defs/url"
+                        "$ref": "#/definitions/url"
                     },
                     "op": {
                         "oneOf": [{

--- a/packages/assertions/assertions-td/td-op-for-event.json
+++ b/packages/assertions/assertions-td/td-op-for-event.json
@@ -8,12 +8,12 @@
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "event_element": {
             "type": "object",
             "properties": {
@@ -21,7 +21,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element_event"
+                        "$ref": "#/definitions/form_element_event"
                     }
                 }
             },
@@ -35,7 +35,7 @@
                 "type": "object",
                 "properties": {
                     "href": {
-                        "$ref": "#/$defs/url"
+                        "$ref": "#/definitions/url"
                     },
                     "op": {
                         "oneOf": [{

--- a/packages/assertions/assertions-td/td-op-for-property.json
+++ b/packages/assertions/assertions-td/td-op-for-property.json
@@ -8,12 +8,12 @@
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "properties": {
@@ -21,7 +21,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element_property"
+                        "$ref": "#/definitions/form_element_property"
                     }
                 }
             },
@@ -35,7 +35,7 @@
                 "type": "object",
                 "properties": {
                     "href": {
-                        "$ref": "#/$defs/url"
+                        "$ref": "#/definitions/url"
                     },
                     "op": {
                         "oneOf": [{

--- a/packages/assertions/assertions-td/td-op-for-thing.json
+++ b/packages/assertions/assertions-td/td-op-for-thing.json
@@ -9,18 +9,18 @@
             "type": "array",
             "minItems": 1,
             "items": {
-                "$ref": "#/$defs/form_element_root"
+                "$ref": "#/definitions/form_element_root"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "form_element_root": {
             "if": {
                 "type": "object",
                 "properties": {
                     "href": {
-                        "$ref": "#/$defs/url"
+                        "$ref": "#/definitions/url"
                     },
                     "op": {
                         "oneOf": [{

--- a/packages/assertions/assertions-td/td-property-arrays.json
+++ b/packages/assertions/assertions-td/td-property-arrays.json
@@ -9,13 +9,13 @@
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         }
 
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {
@@ -24,7 +24,7 @@
                         "type": "array",
                         "minItems": 1,
                         "items": {
-                            "$ref": "#/$defs/form_element"
+                            "$ref": "#/definitions/form_element"
                         }
                     }
                 },
@@ -38,7 +38,7 @@
             "type": "object",
             "properties": {
                 "href": {
-                    "$ref": "#/$defs/url"
+                    "$ref": "#/definitions/url"
                 },
                 "contentType": {
                     "type": "string"

--- a/packages/assertions/assertions-td/td-property-names_at-type.json
+++ b/packages/assertions/assertions-td/td-property-names_at-type.json
@@ -7,12 +7,12 @@
     "properties": {
         "properties": {
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {

--- a/packages/assertions/assertions-td/td-property-names_const.json
+++ b/packages/assertions/assertions-td/td-property-names_const.json
@@ -7,12 +7,12 @@
     "properties": {
         "properties": {
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {

--- a/packages/assertions/assertions-td/td-property-names_description.json
+++ b/packages/assertions/assertions-td/td-property-names_description.json
@@ -7,12 +7,12 @@
     "properties": {
         "properties": {
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {

--- a/packages/assertions/assertions-td/td-property-names_descriptions.json
+++ b/packages/assertions/assertions-td/td-property-names_descriptions.json
@@ -8,12 +8,12 @@
     "properties": {
         "properties": {
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {

--- a/packages/assertions/assertions-td/td-property-names_enum.json
+++ b/packages/assertions/assertions-td/td-property-names_enum.json
@@ -7,12 +7,12 @@
     "properties": {
         "properties": {
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {

--- a/packages/assertions/assertions-td/td-property-names_items.json
+++ b/packages/assertions/assertions-td/td-property-names_items.json
@@ -8,13 +8,13 @@
     "properties": {
         "properties": {
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         }
     },
 
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {

--- a/packages/assertions/assertions-td/td-property-names_maxItems.json
+++ b/packages/assertions/assertions-td/td-property-names_maxItems.json
@@ -7,12 +7,12 @@
     "properties": {
         "properties": {
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {

--- a/packages/assertions/assertions-td/td-property-names_maximum.json
+++ b/packages/assertions/assertions-td/td-property-names_maximum.json
@@ -7,12 +7,12 @@
     "properties": {
         "properties": {
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
          "property_element": {
              "type": "object",
              "if": {

--- a/packages/assertions/assertions-td/td-property-names_minItems.json
+++ b/packages/assertions/assertions-td/td-property-names_minItems.json
@@ -7,12 +7,12 @@
     "properties": {
         "properties": {
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {

--- a/packages/assertions/assertions-td/td-property-names_minimum.json
+++ b/packages/assertions/assertions-td/td-property-names_minimum.json
@@ -7,12 +7,12 @@
     "properties": {
         "properties": {
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {

--- a/packages/assertions/assertions-td/td-property-names_oneOf.json
+++ b/packages/assertions/assertions-td/td-property-names_oneOf.json
@@ -7,12 +7,12 @@
     "properties": {
         "properties": {
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {

--- a/packages/assertions/assertions-td/td-property-names_properties.json
+++ b/packages/assertions/assertions-td/td-property-names_properties.json
@@ -7,12 +7,12 @@
     "properties": {
         "properties": {
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {

--- a/packages/assertions/assertions-td/td-property-names_readOnly.json
+++ b/packages/assertions/assertions-td/td-property-names_readOnly.json
@@ -7,12 +7,12 @@
     "properties": {
         "properties": {
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {

--- a/packages/assertions/assertions-td/td-property-names_required.json
+++ b/packages/assertions/assertions-td/td-property-names_required.json
@@ -7,12 +7,12 @@
     "properties": {
         "properties": {
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {

--- a/packages/assertions/assertions-td/td-property-names_title.json
+++ b/packages/assertions/assertions-td/td-property-names_title.json
@@ -7,12 +7,12 @@
     "properties": {
         "properties": {
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {

--- a/packages/assertions/assertions-td/td-property-names_titles.json
+++ b/packages/assertions/assertions-td/td-property-names_titles.json
@@ -7,12 +7,12 @@
     "properties": {
         "properties": {
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {

--- a/packages/assertions/assertions-td/td-property-names_type.json
+++ b/packages/assertions/assertions-td/td-property-names_type.json
@@ -7,12 +7,12 @@
     "properties": {
         "properties": {
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {

--- a/packages/assertions/assertions-td/td-property-names_unit.json
+++ b/packages/assertions/assertions-td/td-property-names_unit.json
@@ -7,12 +7,12 @@
     "properties": {
         "properties": {
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {

--- a/packages/assertions/assertions-td/td-property-names_uriVariables.json
+++ b/packages/assertions/assertions-td/td-property-names_uriVariables.json
@@ -7,12 +7,12 @@
     "properties": {
         "properties": {
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {

--- a/packages/assertions/assertions-td/td-property-names_writeOnly.json
+++ b/packages/assertions/assertions-td/td-property-names_writeOnly.json
@@ -7,12 +7,12 @@
     "properties": {
         "properties": {
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {

--- a/packages/assertions/assertions-td/td-security-bearer-format-extensions_alg.json
+++ b/packages/assertions/assertions-td/td-security-bearer-format-extensions_alg.json
@@ -9,7 +9,7 @@
             "type": "object",
             "minProperties": 1,
             "additionalProperties": {
-                "$ref": "#/$defs/securityScheme"
+                "$ref": "#/definitions/securityScheme"
             }
         }
     },
@@ -17,7 +17,7 @@
         "securityDefinitions"
     ],
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "securityScheme": {
             "if": {
                 "type": "object",
@@ -26,7 +26,7 @@
                         "type": "string"
                     },
                     "proxy": {
-                        "$ref": "#/$defs/url"
+                        "$ref": "#/definitions/url"
                     },
                     "scheme": {
                         "type": "string",
@@ -35,7 +35,7 @@
                         ]
                     },
                     "authorization": {
-                        "$ref": "#/$defs/url"
+                        "$ref": "#/definitions/url"
                     },
                     "alg": {
                         "type": "string",

--- a/packages/assertions/assertions-td/td-security-bearer-format-extensions_format.json
+++ b/packages/assertions/assertions-td/td-security-bearer-format-extensions_format.json
@@ -9,7 +9,7 @@
             "type": "object",
             "minProperties": 1,
             "additionalProperties": {
-                "$ref": "#/$defs/securityScheme"
+                "$ref": "#/definitions/securityScheme"
             }
         }
     },
@@ -17,7 +17,7 @@
         "securityDefinitions"
     ],
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "securityScheme": {
             "if": {
                 "type": "object",
@@ -26,7 +26,7 @@
                         "type": "string"
                     },
                     "proxy": {
-                        "$ref": "#/$defs/url"
+                        "$ref": "#/definitions/url"
                     },
                     "scheme": {
                         "type": "string",
@@ -35,7 +35,7 @@
                         ]
                     },
                     "authorization": {
-                        "$ref": "#/$defs/url"
+                        "$ref": "#/definitions/url"
                     },
                     "alg": {
                         "type": "string"

--- a/packages/assertions/assertions-td/td-security-combo-exclusive-oneof-or-alloff.json
+++ b/packages/assertions/assertions-td/td-security-combo-exclusive-oneof-or-alloff.json
@@ -9,14 +9,14 @@
       "type": "object",
       "minProperties": 1,
       "additionalProperties": {
-        "$ref": "#/$defs/comboSecurity_element"
+        "$ref": "#/definitions/comboSecurity_element"
       }
     }
   },
   "required": [
     "securityDefinitions"
   ],
-  "$defs": {
+  "definitions": {
     "comboSecurity_element": {
       "if": {
         "type": "object",

--- a/packages/assertions/assertions-td/td-security-in-query-over-uri.json
+++ b/packages/assertions/assertions-td/td-security-in-query-over-uri.json
@@ -9,7 +9,7 @@
             "type": "object",
             "minProperties": 1,
             "additionalProperties": {
-                "$ref": "#/$defs/securityScheme"
+                "$ref": "#/definitions/securityScheme"
             }
         }
     },
@@ -17,7 +17,7 @@
         "securityDefinitions"
     ],
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "securityScheme": {
             "if": {
                 "type": "object",

--- a/packages/assertions/assertions-td/td-security-oauth2-client-flow.json
+++ b/packages/assertions/assertions-td/td-security-oauth2-client-flow.json
@@ -10,7 +10,7 @@
             "type": "object",
             "minProperties": 1,
             "additionalProperties": {
-                "$ref": "#/$defs/securityScheme"
+                "$ref": "#/definitions/securityScheme"
             }
         }
     },
@@ -18,7 +18,7 @@
         "securityDefinitions"
     ],
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "securityScheme": {
             "if": {
                 "type": "object",
@@ -27,7 +27,7 @@
                         "type": "string"
                     },
                     "proxy": {
-                        "$ref": "#/$defs/url"
+                        "$ref": "#/definitions/url"
                     },
                     "scheme": {
                         "type": "string",
@@ -36,10 +36,10 @@
                         ]
                     },
                     "token": {
-                        "$ref": "#/$defs/url"
+                        "$ref": "#/definitions/url"
                     },
                     "refresh": {
-                        "$ref": "#/$defs/url"
+                        "$ref": "#/definitions/url"
                     },
                     "scopes": {
                         "oneOf": [{

--- a/packages/assertions/assertions-td/td-security-oauth2-code-flow.json
+++ b/packages/assertions/assertions-td/td-security-oauth2-code-flow.json
@@ -9,7 +9,7 @@
             "type": "object",
             "minProperties": 1,
             "additionalProperties": {
-                "$ref": "#/$defs/securityScheme"
+                "$ref": "#/definitions/securityScheme"
             }
         }
     },
@@ -17,7 +17,7 @@
         "securityDefinitions"
     ],
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "securityScheme": {
             "if": {
                 "type": "object",
@@ -26,7 +26,7 @@
                         "type": "string"
                     },
                     "proxy": {
-                        "$ref": "#/$defs/url"
+                        "$ref": "#/definitions/url"
                     },
                     "scheme": {
                         "type": "string",
@@ -35,13 +35,13 @@
                         ]
                     },
                     "authorization": {
-                        "$ref": "#/$defs/url"
+                        "$ref": "#/definitions/url"
                     },
                     "token": {
-                        "$ref": "#/$defs/url"
+                        "$ref": "#/definitions/url"
                     },
                     "refresh": {
-                        "$ref": "#/$defs/url"
+                        "$ref": "#/definitions/url"
                     },
                     "scopes": {
                         "oneOf": [{

--- a/packages/assertions/assertions-td/td-security-oauth2-device-flow.json
+++ b/packages/assertions/assertions-td/td-security-oauth2-device-flow.json
@@ -9,7 +9,7 @@
             "type": "object",
             "minProperties": 1,
             "additionalProperties": {
-                "$ref": "#/$defs/securityScheme"
+                "$ref": "#/definitions/securityScheme"
             }
         }
     },
@@ -17,7 +17,7 @@
         "securityDefinitions"
     ],
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "securityScheme": {
             "if": {
                 "type": "object",
@@ -26,7 +26,7 @@
                         "type": "string"
                     },
                     "proxy": {
-                        "$ref": "#/$defs/url"
+                        "$ref": "#/definitions/url"
                     },
                     "scheme": {
                         "type": "string",
@@ -35,10 +35,10 @@
                         ]
                     },
                     "token": {
-                        "$ref": "#/$defs/url"
+                        "$ref": "#/definitions/url"
                     },
                     "refresh": {
-                        "$ref": "#/$defs/url"
+                        "$ref": "#/definitions/url"
                     },
                     "scopes": {
                         "oneOf": [{

--- a/packages/assertions/assertions-td/td-string-type.json
+++ b/packages/assertions/assertions-td/td-string-type.json
@@ -8,24 +8,24 @@
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {
@@ -46,29 +46,29 @@
                 "properties": {
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "uriVariables": {
                         "type": "object",
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -80,10 +80,10 @@
             "type": "object",
             "properties": {
                 "input": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "output": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -91,13 +91,13 @@
             "type": "object",
             "properties": {
                 "subscription": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "data": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "cancellation": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -120,16 +120,16 @@
             "else": {
                 "properties": {
                     "description": {
-                        "$ref": "#/$defs/description"
+                        "$ref": "#/definitions/description"
                     },
                     "title": {
-                        "$ref": "#/$defs/title"
+                        "$ref": "#/definitions/title"
                     },
                     "descriptions": {
-                        "$ref": "#/$defs/descriptions"
+                        "$ref": "#/definitions/descriptions"
                     },
                     "titles": {
-                        "$ref": "#/$defs/titles"
+                        "$ref": "#/definitions/titles"
                     },
                     "writeOnly": {
                         "type": "boolean"
@@ -140,7 +140,7 @@
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "unit": {
@@ -166,12 +166,12 @@
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -196,7 +196,7 @@
                     },
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "required": {

--- a/packages/assertions/assertions-td/td-title-description_descriptions.json
+++ b/packages/assertions/assertions-td/td-title-description_descriptions.json
@@ -8,10 +8,10 @@
         "required": ["descriptions", "description"],
         "properties": {
             "descriptions": {
-                "$ref": "#/$defs/descriptions"
+                "$ref": "#/definitions/descriptions"
             },
             "description": {
-                "$ref": "#/$defs/description"
+                "$ref": "#/definitions/description"
             }
         }
     },
@@ -23,35 +23,35 @@
             "properties": {
                 "type": "object",
                 "additionalProperties": {
-                    "$ref": "#/$defs/property_element"
+                    "$ref": "#/definitions/property_element"
                 }
             },
             "actions": {
                 "type": "object",
                 "additionalProperties": {
-                    "$ref": "#/$defs/action_element"
+                    "$ref": "#/definitions/action_element"
                 }
             },
             "events": {
                 "type": "object",
                 "additionalProperties": {
-                    "$ref": "#/$defs/event_element"
+                    "$ref": "#/definitions/event_element"
                 }
             }
         },
         "additionalProperties": true
     },
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {
                 "required": ["descriptions", "description"],
                 "properties": {
                     "descriptions": {
-                        "$ref": "#/$defs/descriptions"
+                        "$ref": "#/definitions/descriptions"
                     },
                     "description": {
-                        "$ref": "#/$defs/description"
+                        "$ref": "#/definitions/description"
                     }
                 }
             },
@@ -62,29 +62,29 @@
                 "properties": {
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "uriVariables": {
                         "type": "object",
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -98,10 +98,10 @@
                 "required": ["descriptions", "description"],
                 "properties": {
                     "descriptions": {
-                        "$ref": "#/$defs/descriptions"
+                        "$ref": "#/definitions/descriptions"
                     },
                     "description": {
-                        "$ref": "#/$defs/description"
+                        "$ref": "#/definitions/description"
                     }
                 }
             },
@@ -112,10 +112,10 @@
 
                 "properties": {
                     "input": {
-                        "$ref": "#/$defs/dataSchema"
+                        "$ref": "#/definitions/dataSchema"
                     },
                     "output": {
-                        "$ref": "#/$defs/dataSchema"
+                        "$ref": "#/definitions/dataSchema"
                     }
                 }
             }
@@ -126,10 +126,10 @@
                 "required": ["descriptions", "description"],
                 "properties": {
                     "descriptions": {
-                        "$ref": "#/$defs/descriptions"
+                        "$ref": "#/definitions/descriptions"
                     },
                     "description": {
-                        "$ref": "#/$defs/description"
+                        "$ref": "#/definitions/description"
                     }
                 }
             },
@@ -139,13 +139,13 @@
             "else": {
                 "properties": {
                     "subscription": {
-                        "$ref": "#/$defs/dataSchema"
+                        "$ref": "#/definitions/dataSchema"
                     },
                     "data": {
-                        "$ref": "#/$defs/dataSchema"
+                        "$ref": "#/definitions/dataSchema"
                     },
                     "cancellation": {
-                        "$ref": "#/$defs/dataSchema"
+                        "$ref": "#/definitions/dataSchema"
                     }
                 }
             }
@@ -156,10 +156,10 @@
                 "required": ["descriptions", "description"],
                 "properties": {
                     "descriptions": {
-                        "$ref": "#/$defs/descriptions"
+                        "$ref": "#/definitions/descriptions"
                     },
                     "description": {
-                        "$ref": "#/$defs/description"
+                        "$ref": "#/definitions/description"
                     }
                 }
             },
@@ -169,16 +169,16 @@
             "else": {
                 "properties": {
                     "description": {
-                        "$ref": "#/$defs/description"
+                        "$ref": "#/definitions/description"
                     },
                     "title": {
-                        "$ref": "#/$defs/title"
+                        "$ref": "#/definitions/title"
                     },
                     "descriptions": {
-                        "$ref": "#/$defs/descriptions"
+                        "$ref": "#/definitions/descriptions"
                     },
                     "titles": {
-                        "$ref": "#/$defs/titles"
+                        "$ref": "#/definitions/titles"
                     },
                     "writeOnly": {
                         "type": "boolean"
@@ -189,7 +189,7 @@
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "unit": {
@@ -215,12 +215,12 @@
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -243,7 +243,7 @@
                     },
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "required": {

--- a/packages/assertions/assertions-td/td-title-description_titles.json
+++ b/packages/assertions/assertions-td/td-title-description_titles.json
@@ -8,10 +8,10 @@
         "required": ["titles", "title"],
         "properties": {
             "titles": {
-                "$ref": "#/$defs/titles"
+                "$ref": "#/definitions/titles"
             },
             "title": {
-                "$ref": "#/$defs/title"
+                "$ref": "#/definitions/title"
             }
         }
     },
@@ -23,35 +23,35 @@
             "properties": {
                 "type": "object",
                 "additionalProperties": {
-                    "$ref": "#/$defs/property_element"
+                    "$ref": "#/definitions/property_element"
                 }
             },
             "actions": {
                 "type": "object",
                 "additionalProperties": {
-                    "$ref": "#/$defs/action_element"
+                    "$ref": "#/definitions/action_element"
                 }
             },
             "events": {
                 "type": "object",
                 "additionalProperties": {
-                    "$ref": "#/$defs/event_element"
+                    "$ref": "#/definitions/event_element"
                 }
             }
         },
         "additionalProperties": true
     },
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {
                 "required": ["titles", "title"],
                 "properties": {
                     "titles": {
-                        "$ref": "#/$defs/titles"
+                        "$ref": "#/definitions/titles"
                     },
                     "title": {
-                        "$ref": "#/$defs/title"
+                        "$ref": "#/definitions/title"
                     }
                 }
             },
@@ -62,29 +62,29 @@
                 "properties": {
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "uriVariables": {
                         "type": "object",
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -98,10 +98,10 @@
                 "required": ["titles", "title"],
                 "properties": {
                     "titles": {
-                        "$ref": "#/$defs/titles"
+                        "$ref": "#/definitions/titles"
                     },
                     "title": {
-                        "$ref": "#/$defs/title"
+                        "$ref": "#/definitions/title"
                     }
                 }
             },
@@ -112,10 +112,10 @@
 
                 "properties": {
                     "input": {
-                        "$ref": "#/$defs/dataSchema"
+                        "$ref": "#/definitions/dataSchema"
                     },
                     "output": {
-                        "$ref": "#/$defs/dataSchema"
+                        "$ref": "#/definitions/dataSchema"
                     }
                 }
             }
@@ -126,10 +126,10 @@
                 "required": ["titles", "title"],
                 "properties": {
                     "titles": {
-                        "$ref": "#/$defs/titles"
+                        "$ref": "#/definitions/titles"
                     },
                     "title": {
-                        "$ref": "#/$defs/title"
+                        "$ref": "#/definitions/title"
                     }
                 }
             },
@@ -139,13 +139,13 @@
             "else": {
                 "properties": {
                     "subscription": {
-                        "$ref": "#/$defs/dataSchema"
+                        "$ref": "#/definitions/dataSchema"
                     },
                     "data": {
-                        "$ref": "#/$defs/dataSchema"
+                        "$ref": "#/definitions/dataSchema"
                     },
                     "cancellation": {
-                        "$ref": "#/$defs/dataSchema"
+                        "$ref": "#/definitions/dataSchema"
                     }
                 }
             }
@@ -156,10 +156,10 @@
                 "required": ["titles", "title"],
                 "properties": {
                     "titles": {
-                        "$ref": "#/$defs/titles"
+                        "$ref": "#/definitions/titles"
                     },
                     "title": {
-                        "$ref": "#/$defs/title"
+                        "$ref": "#/definitions/title"
                     }
                 }
             },
@@ -169,16 +169,16 @@
             "else": {
                 "properties": {
                     "description": {
-                        "$ref": "#/$defs/description"
+                        "$ref": "#/definitions/description"
                     },
                     "title": {
-                        "$ref": "#/$defs/title"
+                        "$ref": "#/definitions/title"
                     },
                     "descriptions": {
-                        "$ref": "#/$defs/descriptions"
+                        "$ref": "#/definitions/descriptions"
                     },
                     "titles": {
-                        "$ref": "#/$defs/titles"
+                        "$ref": "#/definitions/titles"
                     },
                     "writeOnly": {
                         "type": "boolean"
@@ -189,7 +189,7 @@
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "unit": {
@@ -215,12 +215,12 @@
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -243,7 +243,7 @@
                     },
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "required": {

--- a/packages/assertions/assertions-td/td-vocab-additionalResponses--Form.json
+++ b/packages/assertions/assertions-td/td-vocab-additionalResponses--Form.json
@@ -9,30 +9,30 @@
             "type": "array",
             "minItems": 1,
             "items": {
-                "$ref": "#/$defs/form_element"
+                "$ref": "#/definitions/form_element"
             }
         },
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
 
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "properties": {
@@ -40,7 +40,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element"
+                        "$ref": "#/definitions/form_element"
                     }
                 }
             },
@@ -56,7 +56,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element"
+                        "$ref": "#/definitions/form_element"
                     }
                 }
             },
@@ -72,7 +72,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element"
+                        "$ref": "#/definitions/form_element"
                     }
                 }
             },
@@ -89,12 +89,12 @@
                      "additionalResponses": {
                         "oneOff": [
                             {
-                                "$ref": "#/$defs/additionalResponse_element"
+                                "$ref": "#/definitions/additionalResponse_element"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/additionalResponse_element"
+                                    "$ref": "#/definitions/additionalResponse_element"
                                 }
                             }
                         ]

--- a/packages/assertions/assertions-td/td-vocab-alg--BearerSecurityScheme.json
+++ b/packages/assertions/assertions-td/td-vocab-alg--BearerSecurityScheme.json
@@ -9,7 +9,7 @@
             "type": "object",
             "minProperties": 1,
             "additionalProperties": {
-                "$ref": "#/$defs/securityScheme"
+                "$ref": "#/definitions/securityScheme"
             }
         }
     },
@@ -17,7 +17,7 @@
         "securityDefinitions"
     ],
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "securityScheme": {
             "if": {
                 "type": "object",
@@ -26,7 +26,7 @@
                         "type": "string"
                     },
                     "proxy": {
-                        "$ref": "#/$defs/url"
+                        "$ref": "#/definitions/url"
                     },
                     "scheme": {
                         "type": "string",
@@ -35,7 +35,7 @@
                         ]
                     },
                     "authorization": {
-                        "$ref": "#/$defs/url"
+                        "$ref": "#/definitions/url"
                     },
                     "alg": {
                         "type": "string"

--- a/packages/assertions/assertions-td/td-vocab-allOf--ComboSecurityScheme.json
+++ b/packages/assertions/assertions-td/td-vocab-allOf--ComboSecurityScheme.json
@@ -10,7 +10,7 @@
             "type": "object",
             "minProperties": 1,
             "additionalProperties": {
-                "$ref": "#/$defs/comboSecurity_element"
+                "$ref": "#/definitions/comboSecurity_element"
             }
         }
     },
@@ -19,7 +19,7 @@
     ],
     "additionalProperties": true,
     
-    "$defs": {
+    "definitions": {
         "comboSecurity_element": {
             "type": "object",
             "if": {

--- a/packages/assertions/assertions-td/td-vocab-anchor--Link.json
+++ b/packages/assertions/assertions-td/td-vocab-anchor--Link.json
@@ -8,18 +8,18 @@
         "links": {
             "type": "array",
             "items": {
-                "$ref": "#/$defs/link_element"
+                "$ref": "#/definitions/link_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "link_element": {
             "if": {
                 "type": "object",
                 "properties": {
                     "anchor": {
-                        "$ref": "#/$defs/url"
+                        "$ref": "#/definitions/url"
                     }
                 },
                 "required": [

--- a/packages/assertions/assertions-td/td-vocab-at-type--DataSchema.json
+++ b/packages/assertions/assertions-td/td-vocab-at-type--DataSchema.json
@@ -9,31 +9,31 @@
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {
                 "required": ["@type"],
                 "properties": {
                     "@type": {
-                        "$ref": "#/$defs/type_declaration"
+                        "$ref": "#/definitions/type_declaration"
                     }
                 }
             },
@@ -44,29 +44,29 @@
                 "properties": {
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "uriVariables": {
                         "type": "object",
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -78,10 +78,10 @@
             "type": "object",
             "properties": {
                 "input": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "output": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -89,13 +89,13 @@
             "type": "object",
             "properties": {
                 "subscription": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "data": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "cancellation": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -105,7 +105,7 @@
                 "required": ["@type"],
                 "properties": {
                     "@type": {
-                        "$ref": "#/$defs/type_declaration"
+                        "$ref": "#/definitions/type_declaration"
                     }
                 }
             },
@@ -115,16 +115,16 @@
             "else": {
                 "properties": {
                     "description": {
-                        "$ref": "#/$defs/description"
+                        "$ref": "#/definitions/description"
                     },
                     "title": {
-                        "$ref": "#/$defs/title"
+                        "$ref": "#/definitions/title"
                     },
                     "descriptions": {
-                        "$ref": "#/$defs/descriptions"
+                        "$ref": "#/definitions/descriptions"
                     },
                     "titles": {
-                        "$ref": "#/$defs/titles"
+                        "$ref": "#/definitions/titles"
                     },
                     "writeOnly": {
                         "type": "boolean"
@@ -135,7 +135,7 @@
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "unit": {
@@ -161,12 +161,12 @@
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -189,7 +189,7 @@
                     },
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "required": {

--- a/packages/assertions/assertions-td/td-vocab-at-type--InteractionAffordance.json
+++ b/packages/assertions/assertions-td/td-vocab-at-type--InteractionAffordance.json
@@ -8,31 +8,31 @@
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {
                 "required": ["@type"],
                 "properties": {
                     "@type": {
-                        "$ref": "#/$defs/type_declaration"
+                        "$ref": "#/definitions/type_declaration"
                     }
                 }
             },
@@ -46,7 +46,7 @@
                 "required": ["@type"],
                 "properties": {
                     "@type": {
-                        "$ref": "#/$defs/type_declaration"
+                        "$ref": "#/definitions/type_declaration"
                     }
                 }
             },
@@ -60,7 +60,7 @@
                 "required": ["@type"],
                 "properties": {
                     "@type": {
-                        "$ref": "#/$defs/type_declaration"
+                        "$ref": "#/definitions/type_declaration"
                     }
                 }
             },

--- a/packages/assertions/assertions-td/td-vocab-at-type--SecurityScheme.json
+++ b/packages/assertions/assertions-td/td-vocab-at-type--SecurityScheme.json
@@ -9,7 +9,7 @@
             "type": "object",
             "minProperties": 1,
             "additionalProperties": {
-                "$ref": "#/$defs/securityScheme"
+                "$ref": "#/definitions/securityScheme"
             }
         }
     },
@@ -17,13 +17,13 @@
         "securityDefinitions"
     ],
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "securityScheme": {
             "type": "object",
             "if": {
                 "properties": {
                     "@type": {
-                        "$ref": "#/$defs/type_declaration"
+                        "$ref": "#/definitions/type_declaration"
                     }
                 },
                 "required": ["@type"]

--- a/packages/assertions/assertions-td/td-vocab-at-type--Thing.json
+++ b/packages/assertions/assertions-td/td-vocab-at-type--Thing.json
@@ -7,7 +7,7 @@
         "required": ["@type"],
         "properties": {
             "@type": {
-                "$ref": "#/$defs/type_declaration"
+                "$ref": "#/definitions/type_declaration"
             }
         }
     },
@@ -15,7 +15,7 @@
         "const": "td-vocab-at-type--Thing=pass"
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "type_declaration": {
             "oneOf": [{
                     "type": "string"

--- a/packages/assertions/assertions-td/td-vocab-authorization--BearerSecurityScheme.json
+++ b/packages/assertions/assertions-td/td-vocab-authorization--BearerSecurityScheme.json
@@ -9,7 +9,7 @@
             "type": "object",
             "minProperties": 1,
             "additionalProperties": {
-                "$ref": "#/$defs/securityScheme"
+                "$ref": "#/definitions/securityScheme"
             }
         }
     },
@@ -17,7 +17,7 @@
         "securityDefinitions"
     ],
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "securityScheme": {
             "if": {
                     "type": "object",
@@ -26,7 +26,7 @@
                             "type": "string"
                         },
                         "proxy": {
-                            "$ref": "#/$defs/url"
+                            "$ref": "#/definitions/url"
                         },
                         "scheme": {
                             "type": "string",
@@ -35,7 +35,7 @@
                             ]
                         },
                         "authorization": {
-                            "$ref": "#/$defs/url"
+                            "$ref": "#/definitions/url"
                         },
                         "alg": {
                             "type": "string"

--- a/packages/assertions/assertions-td/td-vocab-authorization--OAuth2SecurityScheme.json
+++ b/packages/assertions/assertions-td/td-vocab-authorization--OAuth2SecurityScheme.json
@@ -9,7 +9,7 @@
             "type": "object",
             "minProperties": 1,
             "additionalProperties": {
-                "$ref": "#/$defs/securityScheme"
+                "$ref": "#/definitions/securityScheme"
             }
         }
     },
@@ -17,7 +17,7 @@
         "securityDefinitions"
     ],
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "securityScheme": {
             "if": {
                     "type": "object",
@@ -26,7 +26,7 @@
                             "type": "string"
                         },
                         "proxy": {
-                            "$ref": "#/$defs/url"
+                            "$ref": "#/definitions/url"
                         },
                         "scheme": {
                             "type": "string",
@@ -35,13 +35,13 @@
                             ]
                         },
                         "authorization": {
-                            "$ref": "#/$defs/url"
+                            "$ref": "#/definitions/url"
                         },
                         "token": {
-                            "$ref": "#/$defs/url"
+                            "$ref": "#/definitions/url"
                         },
                         "refresh": {
-                            "$ref": "#/$defs/url"
+                            "$ref": "#/definitions/url"
                         },
                         "scopes": {
                             "type": "array",

--- a/packages/assertions/assertions-td/td-vocab-cancellation--EventAffordance.json
+++ b/packages/assertions/assertions-td/td-vocab-cancellation--EventAffordance.json
@@ -9,18 +9,18 @@
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "event_element": {
             "if":{
                 "type": "object",
                 "properties": {
                     "cancellation": {
-                        "$ref": "#/$defs/dataSchema"
+                        "$ref": "#/definitions/dataSchema"
                     }
                 },
                 "required": [
@@ -42,10 +42,10 @@
                     "type": "string"
                 },
                 "descriptions": {
-                    "$ref": "#/$defs/descriptions"
+                    "$ref": "#/definitions/descriptions"
                 },
                 "titles": {
-                    "$ref": "#/$defs/titles"
+                    "$ref": "#/definitions/titles"
                 },
                 "writeOnly": {
                     "type": "boolean"
@@ -56,7 +56,7 @@
                 "oneOf": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/$defs/dataSchema"
+                        "$ref": "#/definitions/dataSchema"
                     }
                 },
                 "unit": {
@@ -82,12 +82,12 @@
                 },
                 "items": {
                     "oneOf": [{
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         },
                         {
                             "type": "array",
                             "items": {
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             }
                         }
                     ]
@@ -112,7 +112,7 @@
                 },
                 "properties": {
                     "additionalProperties": {
-                        "$ref": "#/$defs/dataSchema"
+                        "$ref": "#/definitions/dataSchema"
                     }
                 },
                 "required": {

--- a/packages/assertions/assertions-td/td-vocab-const--DataSchema.json
+++ b/packages/assertions/assertions-td/td-vocab-const--DataSchema.json
@@ -9,24 +9,24 @@
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {
@@ -42,29 +42,29 @@
                 "properties": {
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "uriVariables": {
                         "type": "object",
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -76,10 +76,10 @@
             "type": "object",
             "properties": {
                 "input": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "output": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -87,13 +87,13 @@
             "type": "object",
             "properties": {
                 "subscription": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "data": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "cancellation": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -111,16 +111,16 @@
             "else": {
                 "properties": {
                     "description": {
-                        "$ref": "#/$defs/description"
+                        "$ref": "#/definitions/description"
                     },
                     "title": {
-                        "$ref": "#/$defs/title"
+                        "$ref": "#/definitions/title"
                     },
                     "descriptions": {
-                        "$ref": "#/$defs/descriptions"
+                        "$ref": "#/definitions/descriptions"
                     },
                     "titles": {
-                        "$ref": "#/$defs/titles"
+                        "$ref": "#/definitions/titles"
                     },
                     "writeOnly": {
                         "type": "boolean"
@@ -131,7 +131,7 @@
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "unit": {
@@ -157,12 +157,12 @@
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -187,7 +187,7 @@
                     },
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "required": {

--- a/packages/assertions/assertions-td/td-vocab-contentCoding.json
+++ b/packages/assertions/assertions-td/td-vocab-contentCoding.json
@@ -9,32 +9,32 @@
             "type": "array",
             "minItems": 1,
             "items": {
-                "$ref": "#/$defs/form_element"
+                "$ref": "#/definitions/form_element"
             }
         },
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
 
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
 
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "properties": {
@@ -42,7 +42,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element"
+                        "$ref": "#/definitions/form_element"
                     }
                 }
             },
@@ -58,7 +58,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element"
+                        "$ref": "#/definitions/form_element"
                     }
                 }
             },
@@ -74,7 +74,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element"
+                        "$ref": "#/definitions/form_element"
                     }
                 }
             },

--- a/packages/assertions/assertions-td/td-vocab-contentEncoding--StringSchema.json
+++ b/packages/assertions/assertions-td/td-vocab-contentEncoding--StringSchema.json
@@ -9,35 +9,35 @@
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
-            "$ref": "#/$defs/dataSchema"
+            "$ref": "#/definitions/dataSchema"
         },
         "action_element": {
             "type": "object",
             "properties": {
                 "input": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "output": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -45,13 +45,13 @@
             "type": "object",
             "properties": {
                 "subscription": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "data": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "cancellation": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -77,16 +77,16 @@
             "else": {
                 "properties": {
                     "description": {
-                        "$ref": "#/$defs/description"
+                        "$ref": "#/definitions/description"
                     },
                     "title": {
-                        "$ref": "#/$defs/title"
+                        "$ref": "#/definitions/title"
                     },
                     "descriptions": {
-                        "$ref": "#/$defs/descriptions"
+                        "$ref": "#/definitions/descriptions"
                     },
                     "titles": {
-                        "$ref": "#/$defs/titles"
+                        "$ref": "#/definitions/titles"
                     },
                     "writeOnly": {
                         "type": "boolean"
@@ -97,7 +97,7 @@
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "unit": {
@@ -123,12 +123,12 @@
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -153,7 +153,7 @@
                     },
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "required": {

--- a/packages/assertions/assertions-td/td-vocab-contentMediaType--StringSchema.json
+++ b/packages/assertions/assertions-td/td-vocab-contentMediaType--StringSchema.json
@@ -9,35 +9,35 @@
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
-            "$ref": "#/$defs/dataSchema"
+            "$ref": "#/definitions/dataSchema"
         },
         "action_element": {
             "type": "object",
             "properties": {
                 "input": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "output": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -45,13 +45,13 @@
             "type": "object",
             "properties": {
                 "subscription": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "data": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "cancellation": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -77,16 +77,16 @@
             "else": {
                 "properties": {
                     "description": {
-                        "$ref": "#/$defs/description"
+                        "$ref": "#/definitions/description"
                     },
                     "title": {
-                        "$ref": "#/$defs/title"
+                        "$ref": "#/definitions/title"
                     },
                     "descriptions": {
-                        "$ref": "#/$defs/descriptions"
+                        "$ref": "#/definitions/descriptions"
                     },
                     "titles": {
-                        "$ref": "#/$defs/titles"
+                        "$ref": "#/definitions/titles"
                     },
                     "writeOnly": {
                         "type": "boolean"
@@ -97,7 +97,7 @@
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "unit": {
@@ -123,12 +123,12 @@
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -153,7 +153,7 @@
                     },
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "required": {

--- a/packages/assertions/assertions-td/td-vocab-contentType--AdditionalExpectedResponse.json
+++ b/packages/assertions/assertions-td/td-vocab-contentType--AdditionalExpectedResponse.json
@@ -10,30 +10,30 @@
             "type": "array",
             "minItems": 1,
             "items": {
-                "$ref": "#/$defs/form_element"
+                "$ref": "#/definitions/form_element"
             }
         },
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
 
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "properties": {
@@ -41,7 +41,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element"
+                        "$ref": "#/definitions/form_element"
                     }
                 }
             },
@@ -57,7 +57,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element"
+                        "$ref": "#/definitions/form_element"
                     }
                 }
             },
@@ -73,7 +73,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element"
+                        "$ref": "#/definitions/form_element"
                     }
                 }
             },
@@ -90,12 +90,12 @@
                      "additionalResponses": {
                         "oneOff": [
                             {
-                                "$ref": "#/$defs/additionalResponse_element"
+                                "$ref": "#/definitions/additionalResponse_element"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/additionalResponse_element"
+                                    "$ref": "#/definitions/additionalResponse_element"
                                 }
                             }
                         ]

--- a/packages/assertions/assertions-td/td-vocab-contentType-Form.json
+++ b/packages/assertions/assertions-td/td-vocab-contentType-Form.json
@@ -9,32 +9,32 @@
             "type": "array",
             "minItems": 1,
             "items": {
-                "$ref": "#/$defs/form_element"
+                "$ref": "#/definitions/form_element"
             }
         },
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
 
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
 
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "properties": {
@@ -42,7 +42,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element"
+                        "$ref": "#/definitions/form_element"
                     }
                 }
             },
@@ -58,7 +58,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element"
+                        "$ref": "#/definitions/form_element"
                     }
                 }
             },
@@ -74,7 +74,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element"
+                        "$ref": "#/definitions/form_element"
                     }
                 }
             },

--- a/packages/assertions/assertions-td/td-vocab-data--EventAffordance.json
+++ b/packages/assertions/assertions-td/td-vocab-data--EventAffordance.json
@@ -9,18 +9,18 @@
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "event_element": {
             "if": {
                 "type": "object",
                 "properties": {
                     "data": {
-                        "$ref": "#/$defs/dataSchema"
+                        "$ref": "#/definitions/dataSchema"
                     }
                 },
                 "required": [
@@ -42,10 +42,10 @@
                     "type": "string"
                 },
                 "descriptions": {
-                    "$ref": "#/$defs/descriptions"
+                    "$ref": "#/definitions/descriptions"
                 },
                 "titles": {
-                    "$ref": "#/$defs/titles"
+                    "$ref": "#/definitions/titles"
                 },
                 "writeOnly": {
                     "type": "boolean"
@@ -56,7 +56,7 @@
                 "oneOf": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/$defs/dataSchema"
+                        "$ref": "#/definitions/dataSchema"
                     }
                 },
                 "unit": {
@@ -82,12 +82,12 @@
                 },
                 "items": {
                     "oneOf": [{
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         },
                         {
                             "type": "array",
                             "items": {
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             }
                         }
                     ]
@@ -112,7 +112,7 @@
                 },
                 "properties": {
                     "additionalProperties": {
-                        "$ref": "#/$defs/dataSchema"
+                        "$ref": "#/definitions/dataSchema"
                     }
                 },
                 "required": {

--- a/packages/assertions/assertions-td/td-vocab-dataResponse--EventAffordance.json
+++ b/packages/assertions/assertions-td/td-vocab-dataResponse--EventAffordance.json
@@ -9,18 +9,18 @@
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "event_element": {
             "if": {
                 "type": "object",
                 "properties": {
                     "dataResponse": {
-                        "$ref": "#/$defs/dataSchema"
+                        "$ref": "#/definitions/dataSchema"
                     }
                 },
                 "required": [
@@ -42,10 +42,10 @@
                     "type": "string"
                 },
                 "descriptions": {
-                    "$ref": "#/$defs/descriptions"
+                    "$ref": "#/definitions/descriptions"
                 },
                 "titles": {
-                    "$ref": "#/$defs/titles"
+                    "$ref": "#/definitions/titles"
                 },
                 "writeOnly": {
                     "type": "boolean"
@@ -56,7 +56,7 @@
                 "oneOf": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/$defs/dataSchema"
+                        "$ref": "#/definitions/dataSchema"
                     }
                 },
                 "unit": {
@@ -82,12 +82,12 @@
                 },
                 "items": {
                     "oneOf": [{
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         },
                         {
                             "type": "array",
                             "items": {
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             }
                         }
                     ]
@@ -112,7 +112,7 @@
                 },
                 "properties": {
                     "additionalProperties": {
-                        "$ref": "#/$defs/dataSchema"
+                        "$ref": "#/definitions/dataSchema"
                     }
                 },
                 "required": {

--- a/packages/assertions/assertions-td/td-vocab-default--DataSchema.json
+++ b/packages/assertions/assertions-td/td-vocab-default--DataSchema.json
@@ -8,35 +8,35 @@
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
-            "$ref": "#/$defs/dataSchema"
+            "$ref": "#/definitions/dataSchema"
         },
         "action_element": {
             "type": "object",
             "properties": {
                 "input": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "output": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -44,13 +44,13 @@
             "type": "object",
             "properties": {
                 "subscription": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "data": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "cancellation": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -65,16 +65,16 @@
             "else": {
                 "properties": {
                     "description": {
-                        "$ref": "#/$defs/description"
+                        "$ref": "#/definitions/description"
                     },
                     "title": {
-                        "$ref": "#/$defs/title"
+                        "$ref": "#/definitions/title"
                     },
                     "descriptions": {
-                        "$ref": "#/$defs/descriptions"
+                        "$ref": "#/definitions/descriptions"
                     },
                     "titles": {
-                        "$ref": "#/$defs/titles"
+                        "$ref": "#/definitions/titles"
                     },
                     "writeOnly": {
                         "type": "boolean"
@@ -85,7 +85,7 @@
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "unit": {
@@ -111,12 +111,12 @@
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -141,7 +141,7 @@
                     },
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "required": {

--- a/packages/assertions/assertions-td/td-vocab-description--DataSchema.json
+++ b/packages/assertions/assertions-td/td-vocab-description--DataSchema.json
@@ -9,31 +9,31 @@
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {
                 "required": ["description"],
                 "properties": {
                     "description": {
-                        "$ref": "#/$defs/description"
+                        "$ref": "#/definitions/description"
                     }
                 }
             },
@@ -44,29 +44,29 @@
                 "properties": {
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "uriVariables": {
                         "type": "object",
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -80,7 +80,7 @@
                 "required": ["description"],
                 "properties": {
                     "description": {
-                        "$ref": "#/$defs/description"
+                        "$ref": "#/definitions/description"
                     }
                 }
             },
@@ -90,10 +90,10 @@
             "else": {
                 "properties": {
                     "input": {
-                        "$ref": "#/$defs/dataSchema"
+                        "$ref": "#/definitions/dataSchema"
                     },
                     "output": {
-                        "$ref": "#/$defs/dataSchema"
+                        "$ref": "#/definitions/dataSchema"
                     }
                 }
             }
@@ -104,7 +104,7 @@
                 "required": ["description"],
                 "properties": {
                     "description": {
-                        "$ref": "#/$defs/description"
+                        "$ref": "#/definitions/description"
                     }
                 }
             },
@@ -114,13 +114,13 @@
             "else": {
                 "properties": {
                     "subscription": {
-                        "$ref": "#/$defs/dataSchema"
+                        "$ref": "#/definitions/dataSchema"
                     },
                     "data": {
-                        "$ref": "#/$defs/dataSchema"
+                        "$ref": "#/definitions/dataSchema"
                     },
                     "cancellation": {
-                        "$ref": "#/$defs/dataSchema"
+                        "$ref": "#/definitions/dataSchema"
                     }
                 }
             }
@@ -131,7 +131,7 @@
                 "required": ["description"],
                 "properties": {
                     "description": {
-                        "$ref": "#/$defs/description"
+                        "$ref": "#/definitions/description"
                     }
                 }
             },
@@ -141,16 +141,16 @@
             "else": {
                 "properties": {
                     "description": {
-                        "$ref": "#/$defs/description"
+                        "$ref": "#/definitions/description"
                     },
                     "title": {
-                        "$ref": "#/$defs/title"
+                        "$ref": "#/definitions/title"
                     },
                     "descriptions": {
-                        "$ref": "#/$defs/descriptions"
+                        "$ref": "#/definitions/descriptions"
                     },
                     "titles": {
-                        "$ref": "#/$defs/titles"
+                        "$ref": "#/definitions/titles"
                     },
                     "writeOnly": {
                         "type": "boolean"
@@ -161,7 +161,7 @@
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "unit": {
@@ -187,12 +187,12 @@
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -215,7 +215,7 @@
                     },
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "required": {

--- a/packages/assertions/assertions-td/td-vocab-description--InteractionAffordance.json
+++ b/packages/assertions/assertions-td/td-vocab-description--InteractionAffordance.json
@@ -8,31 +8,31 @@
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {
                 "required": ["description"],
                 "properties": {
                     "description": {
-                        "$ref": "#/$defs/description"
+                        "$ref": "#/definitions/description"
                     }
                 }
             },
@@ -43,29 +43,29 @@
                 "properties": {
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "uriVariables": {
                         "type": "object",
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -79,7 +79,7 @@
                 "required": ["description"],
                 "properties": {
                     "description": {
-                        "$ref": "#/$defs/description"
+                        "$ref": "#/definitions/description"
                     }
                 }
             },
@@ -90,10 +90,10 @@
 
                 "properties": {
                     "input": {
-                        "$ref": "#/$defs/dataSchema"
+                        "$ref": "#/definitions/dataSchema"
                     },
                     "output": {
-                        "$ref": "#/$defs/dataSchema"
+                        "$ref": "#/definitions/dataSchema"
                     }
                 }
             }
@@ -104,7 +104,7 @@
                 "required": ["description"],
                 "properties": {
                     "description": {
-                        "$ref": "#/$defs/description"
+                        "$ref": "#/definitions/description"
                     }
                 }
             },
@@ -114,13 +114,13 @@
             "else": {
                 "properties": {
                     "subscription": {
-                        "$ref": "#/$defs/dataSchema"
+                        "$ref": "#/definitions/dataSchema"
                     },
                     "data": {
-                        "$ref": "#/$defs/dataSchema"
+                        "$ref": "#/definitions/dataSchema"
                     },
                     "cancellation": {
-                        "$ref": "#/$defs/dataSchema"
+                        "$ref": "#/definitions/dataSchema"
                     }
                 }
             }
@@ -129,16 +129,16 @@
             "type": "object",
             "properties": {
                 "description": {
-                    "$ref": "#/$defs/description"
+                    "$ref": "#/definitions/description"
                 },
                 "title": {
-                    "$ref": "#/$defs/title"
+                    "$ref": "#/definitions/title"
                 },
                 "descriptions": {
-                    "$ref": "#/$defs/descriptions"
+                    "$ref": "#/definitions/descriptions"
                 },
                 "titles": {
-                    "$ref": "#/$defs/titles"
+                    "$ref": "#/definitions/titles"
                 },
                 "writeOnly": {
                     "type": "boolean"
@@ -149,7 +149,7 @@
                 "oneOf": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/$defs/dataSchema"
+                        "$ref": "#/definitions/dataSchema"
                     }
                 },
                 "unit": {
@@ -175,12 +175,12 @@
                 },
                 "items": {
                     "oneOf": [{
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         },
                         {
                             "type": "array",
                             "items": {
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             }
                         }
                     ]
@@ -201,7 +201,7 @@
                 },
                 "properties": {
                     "additionalProperties": {
-                        "$ref": "#/$defs/dataSchema"
+                        "$ref": "#/definitions/dataSchema"
                     }
                 },
                 "required": {

--- a/packages/assertions/assertions-td/td-vocab-description--SecurityScheme.json
+++ b/packages/assertions/assertions-td/td-vocab-description--SecurityScheme.json
@@ -9,7 +9,7 @@
             "type": "object",
             "minProperties": 1,
             "additionalProperties": {
-                "$ref": "#/$defs/securityScheme"
+                "$ref": "#/definitions/securityScheme"
             }
         }
     },
@@ -17,7 +17,7 @@
         "securityDefinitions"
     ],
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "securityScheme": {
             "if": {
                 "type": "object",

--- a/packages/assertions/assertions-td/td-vocab-description--Thing.json
+++ b/packages/assertions/assertions-td/td-vocab-description--Thing.json
@@ -6,11 +6,11 @@
     "type": "object",
     "properties": {
         "description": {
-            "$ref": "#/$defs/description"
+            "$ref": "#/definitions/description"
         }
     },
     "required": ["description"],
-    "$defs": {
+    "definitions": {
         "description": {
             "type": "string"
         }

--- a/packages/assertions/assertions-td/td-vocab-descriptions--DataSchema.json
+++ b/packages/assertions/assertions-td/td-vocab-descriptions--DataSchema.json
@@ -9,31 +9,31 @@
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {
                 "required": ["descriptions"],
                 "properties": {
                     "descriptions": {
-                        "$ref": "#/$defs/descriptions"
+                        "$ref": "#/definitions/descriptions"
                     }
                 }
             },
@@ -44,29 +44,29 @@
                 "properties": {
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "uriVariables": {
                         "type": "object",
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -80,7 +80,7 @@
                 "required": ["descriptions"],
                 "properties": {
                     "descriptions": {
-                        "$ref": "#/$defs/descriptions"
+                        "$ref": "#/definitions/descriptions"
                     }
                 }
             },
@@ -91,10 +91,10 @@
 
                 "properties": {
                     "input": {
-                        "$ref": "#/$defs/dataSchema"
+                        "$ref": "#/definitions/dataSchema"
                     },
                     "output": {
-                        "$ref": "#/$defs/dataSchema"
+                        "$ref": "#/definitions/dataSchema"
                     }
                 }
             }
@@ -105,7 +105,7 @@
                 "required": ["descriptions"],
                 "properties": {
                     "descriptions": {
-                        "$ref": "#/$defs/descriptions"
+                        "$ref": "#/definitions/descriptions"
                     }
                 }
             },
@@ -115,13 +115,13 @@
             "else": {
                 "properties": {
                     "subscription": {
-                        "$ref": "#/$defs/dataSchema"
+                        "$ref": "#/definitions/dataSchema"
                     },
                     "data": {
-                        "$ref": "#/$defs/dataSchema"
+                        "$ref": "#/definitions/dataSchema"
                     },
                     "cancellation": {
-                        "$ref": "#/$defs/dataSchema"
+                        "$ref": "#/definitions/dataSchema"
                     }
                 }
             }
@@ -132,7 +132,7 @@
                 "required": ["descriptions"],
                 "properties": {
                     "descriptions": {
-                        "$ref": "#/$defs/descriptions"
+                        "$ref": "#/definitions/descriptions"
                     }
                 }
             },
@@ -142,16 +142,16 @@
             "else": {
                 "properties": {
                     "description": {
-                        "$ref": "#/$defs/description"
+                        "$ref": "#/definitions/description"
                     },
                     "title": {
-                        "$ref": "#/$defs/title"
+                        "$ref": "#/definitions/title"
                     },
                     "descriptions": {
-                        "$ref": "#/$defs/descriptions"
+                        "$ref": "#/definitions/descriptions"
                     },
                     "titles": {
-                        "$ref": "#/$defs/titles"
+                        "$ref": "#/definitions/titles"
                     },
                     "writeOnly": {
                         "type": "boolean"
@@ -162,7 +162,7 @@
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "unit": {
@@ -188,12 +188,12 @@
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -216,7 +216,7 @@
                     },
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "required": {

--- a/packages/assertions/assertions-td/td-vocab-descriptions--InteractionAffordance.json
+++ b/packages/assertions/assertions-td/td-vocab-descriptions--InteractionAffordance.json
@@ -9,31 +9,31 @@
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {
                 "required": ["descriptions"],
                 "properties": {
                     "descriptions": {
-                        "$ref": "#/$defs/descriptions"
+                        "$ref": "#/definitions/descriptions"
                     }
                 }
             },
@@ -44,29 +44,29 @@
                 "properties": {
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "uriVariables": {
                         "type": "object",
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -80,7 +80,7 @@
                 "required": ["descriptions"],
                 "properties": {
                     "descriptions": {
-                        "$ref": "#/$defs/descriptions"
+                        "$ref": "#/definitions/descriptions"
                     }
                 }
             },
@@ -91,10 +91,10 @@
 
                 "properties": {
                     "input": {
-                        "$ref": "#/$defs/dataSchema"
+                        "$ref": "#/definitions/dataSchema"
                     },
                     "output": {
-                        "$ref": "#/$defs/dataSchema"
+                        "$ref": "#/definitions/dataSchema"
                     }
                 }
             }
@@ -105,7 +105,7 @@
                 "required": ["descriptions"],
                 "properties": {
                     "descriptions": {
-                        "$ref": "#/$defs/descriptions"
+                        "$ref": "#/definitions/descriptions"
                     }
                 }
             },
@@ -115,13 +115,13 @@
             "else": {
                 "properties": {
                     "subscription": {
-                        "$ref": "#/$defs/dataSchema"
+                        "$ref": "#/definitions/dataSchema"
                     },
                     "data": {
-                        "$ref": "#/$defs/dataSchema"
+                        "$ref": "#/definitions/dataSchema"
                     },
                     "cancellation": {
-                        "$ref": "#/$defs/dataSchema"
+                        "$ref": "#/definitions/dataSchema"
                     }
                 }
             }
@@ -130,16 +130,16 @@
             "type": "object",
             "properties": {
                 "description": {
-                    "$ref": "#/$defs/description"
+                    "$ref": "#/definitions/description"
                 },
                 "title": {
-                    "$ref": "#/$defs/title"
+                    "$ref": "#/definitions/title"
                 },
                 "descriptions": {
-                    "$ref": "#/$defs/descriptions"
+                    "$ref": "#/definitions/descriptions"
                 },
                 "titles": {
-                    "$ref": "#/$defs/titles"
+                    "$ref": "#/definitions/titles"
                 },
                 "writeOnly": {
                     "type": "boolean"
@@ -150,7 +150,7 @@
                 "oneOf": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/$defs/dataSchema"
+                        "$ref": "#/definitions/dataSchema"
                     }
                 },
                 "unit": {
@@ -176,12 +176,12 @@
                 },
                 "items": {
                     "oneOf": [{
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         },
                         {
                             "type": "array",
                             "items": {
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             }
                         }
                     ]
@@ -204,7 +204,7 @@
                 },
                 "properties": {
                     "additionalProperties": {
-                        "$ref": "#/$defs/dataSchema"
+                        "$ref": "#/definitions/dataSchema"
                     }
                 },
                 "required": {

--- a/packages/assertions/assertions-td/td-vocab-descriptions--SecurityScheme.json
+++ b/packages/assertions/assertions-td/td-vocab-descriptions--SecurityScheme.json
@@ -10,7 +10,7 @@
             "type": "object",
             "minProperties": 1,
             "additionalProperties": {
-                "$ref": "#/$defs/securityScheme"
+                "$ref": "#/definitions/securityScheme"
             }
         }
     },
@@ -18,13 +18,13 @@
         "securityDefinitions"
     ],
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "securityScheme": {
             "if": {
                 "type": "object",
                 "properties": {
                     "descriptions": {
-                        "$ref": "#/$defs/descriptions"
+                        "$ref": "#/definitions/descriptions"
                     }
                 },
                 "required": [

--- a/packages/assertions/assertions-td/td-vocab-descriptions--Thing.json
+++ b/packages/assertions/assertions-td/td-vocab-descriptions--Thing.json
@@ -7,11 +7,11 @@
     "type": "object",
     "properties": {
         "descriptions": {
-            "$ref": "#/$defs/descriptions"
+            "$ref": "#/definitions/descriptions"
         }
     },
     "required": ["descriptions"],
-    "$defs": {
+    "definitions": {
         "descriptions": {
             "type": "object",
             "additionalProperties": {

--- a/packages/assertions/assertions-td/td-vocab-enum--DataSchema.json
+++ b/packages/assertions/assertions-td/td-vocab-enum--DataSchema.json
@@ -9,24 +9,24 @@
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {
@@ -46,29 +46,29 @@
                 "properties": {
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "uriVariables": {
                         "type": "object",
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -80,10 +80,10 @@
             "type": "object",
             "properties": {
                 "input": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "output": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -91,13 +91,13 @@
             "type": "object",
             "properties": {
                 "subscription": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "data": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "cancellation": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -119,16 +119,16 @@
             "else": {
                 "properties": {
                     "description": {
-                        "$ref": "#/$defs/description"
+                        "$ref": "#/definitions/description"
                     },
                     "title": {
-                        "$ref": "#/$defs/title"
+                        "$ref": "#/definitions/title"
                     },
                     "descriptions": {
-                        "$ref": "#/$defs/descriptions"
+                        "$ref": "#/definitions/descriptions"
                     },
                     "titles": {
-                        "$ref": "#/$defs/titles"
+                        "$ref": "#/definitions/titles"
                     },
                     "writeOnly": {
                         "type": "boolean"
@@ -139,7 +139,7 @@
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "unit": {
@@ -165,12 +165,12 @@
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -195,7 +195,7 @@
                     },
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "required": {

--- a/packages/assertions/assertions-td/td-vocab-exclusiveMaximum--IntegerSchema.json
+++ b/packages/assertions/assertions-td/td-vocab-exclusiveMaximum--IntegerSchema.json
@@ -9,35 +9,35 @@
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
-            "$ref": "#/$defs/dataSchema"
+            "$ref": "#/definitions/dataSchema"
         },
         "action_element": {
             "type": "object",
             "properties": {
                 "input": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "output": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -45,13 +45,13 @@
             "type": "object",
             "properties": {
                 "subscription": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "data": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "cancellation": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -78,29 +78,29 @@
                 "properties": {
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "uriVariables": {
                         "type": "object",
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]

--- a/packages/assertions/assertions-td/td-vocab-exclusiveMaximum--NumberSchema.json
+++ b/packages/assertions/assertions-td/td-vocab-exclusiveMaximum--NumberSchema.json
@@ -9,35 +9,35 @@
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
-            "$ref": "#/$defs/dataSchema"
+            "$ref": "#/definitions/dataSchema"
         },
         "action_element": {
             "type": "object",
             "properties": {
                 "input": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "output": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -45,13 +45,13 @@
             "type": "object",
             "properties": {
                 "subscription": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "data": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "cancellation": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -78,29 +78,29 @@
                 "properties": {
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "uriVariables": {
                         "type": "object",
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]

--- a/packages/assertions/assertions-td/td-vocab-exclusiveMinimum--IntegerSchema.json
+++ b/packages/assertions/assertions-td/td-vocab-exclusiveMinimum--IntegerSchema.json
@@ -9,35 +9,35 @@
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
-            "$ref": "#/$defs/dataSchema"
+            "$ref": "#/definitions/dataSchema"
         },
         "action_element": {
             "type": "object",
             "properties": {
                 "input": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "output": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -45,13 +45,13 @@
             "type": "object",
             "properties": {
                 "subscription": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "data": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "cancellation": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -78,29 +78,29 @@
                 "properties": {
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "uriVariables": {
                         "type": "object",
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]

--- a/packages/assertions/assertions-td/td-vocab-exclusiveMinimum--NumberSchema.json
+++ b/packages/assertions/assertions-td/td-vocab-exclusiveMinimum--NumberSchema.json
@@ -9,35 +9,35 @@
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
-            "$ref": "#/$defs/dataSchema"
+            "$ref": "#/definitions/dataSchema"
         },
         "action_element": {
             "type": "object",
             "properties": {
                 "input": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "output": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -45,13 +45,13 @@
             "type": "object",
             "properties": {
                 "subscription": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "data": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "cancellation": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -78,29 +78,29 @@
                 "properties": {
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "uriVariables": {
                         "type": "object",
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]

--- a/packages/assertions/assertions-td/td-vocab-flow--OAuth2SecurityScheme.json
+++ b/packages/assertions/assertions-td/td-vocab-flow--OAuth2SecurityScheme.json
@@ -9,7 +9,7 @@
             "type": "object",
             "minProperties": 1,
             "additionalProperties": {
-                "$ref": "#/$defs/securityScheme"
+                "$ref": "#/definitions/securityScheme"
             }
         }
     },
@@ -17,7 +17,7 @@
         "securityDefinitions"
     ],
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "securityScheme": {
             "if": {
                 "type": "object",
@@ -26,7 +26,7 @@
                         "type": "string"
                     },
                     "proxy": {
-                        "$ref": "#/$defs/url"
+                        "$ref": "#/definitions/url"
                     },
                     "scheme": {
                         "type": "string",
@@ -35,13 +35,13 @@
                         ]
                     },
                     "authorization": {
-                        "$ref": "#/$defs/url"
+                        "$ref": "#/definitions/url"
                     },
                     "token": {
-                        "$ref": "#/$defs/url"
+                        "$ref": "#/definitions/url"
                     },
                     "refresh": {
-                        "$ref": "#/$defs/url"
+                        "$ref": "#/definitions/url"
                     },
                     "scopes": {
                         "type": "array",

--- a/packages/assertions/assertions-td/td-vocab-format--BearerSecurityScheme.json
+++ b/packages/assertions/assertions-td/td-vocab-format--BearerSecurityScheme.json
@@ -9,7 +9,7 @@
             "type": "object",
             "minProperties": 1,
             "additionalProperties": {
-                "$ref": "#/$defs/securityScheme"
+                "$ref": "#/definitions/securityScheme"
             }
         }
     },
@@ -17,7 +17,7 @@
         "securityDefinitions"
     ],
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "securityScheme": {
             "if": {
                 "type": "object",
@@ -26,7 +26,7 @@
                         "type": "string"
                     },
                     "proxy": {
-                        "$ref": "#/$defs/url"
+                        "$ref": "#/definitions/url"
                     },
                     "scheme": {
                         "type": "string",
@@ -35,7 +35,7 @@
                         ]
                     },
                     "authorization": {
-                        "$ref": "#/$defs/url"
+                        "$ref": "#/definitions/url"
                     },
                     "alg": {
                         "type": "string"

--- a/packages/assertions/assertions-td/td-vocab-format--DataSchema.json
+++ b/packages/assertions/assertions-td/td-vocab-format--DataSchema.json
@@ -1,6 +1,6 @@
 {
     "title": "td-vocab-format--DataSchema",
-    "description": "format: Defines format pattern validation on certain kinds of string values. It is open to use pattern values that may originate from JSON schema presets (e.g., date/time, email, URL) or other (customer-based) $defs. . MAY be included. Type: string.",
+    "description": "format: Defines format pattern validation on certain kinds of string values. It is open to use pattern values that may originate from JSON schema presets (e.g., date/time, email, URL) or other (customer-based) definitions. . MAY be included. Type: string.",
     "$schema": "http://json-schema.org/draft-07/schema#",
     "also": ["td-data-schema_format", "td-format-validation-known-values", "td-property-names_format"],
     "is-complex": true,
@@ -9,24 +9,24 @@
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {
@@ -44,29 +44,29 @@
                 "properties": {
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "uriVariables": {
                         "type": "object",
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -78,10 +78,10 @@
             "type": "object",
             "properties": {
                 "input": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "output": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -89,13 +89,13 @@
             "type": "object",
             "properties": {
                 "subscription": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "data": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "cancellation": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -117,7 +117,7 @@
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "type": {
@@ -134,19 +134,19 @@
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
                     },
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "required": {

--- a/packages/assertions/assertions-td/td-vocab-forms--InteractionAffordance.json
+++ b/packages/assertions/assertions-td/td-vocab-forms--InteractionAffordance.json
@@ -9,25 +9,25 @@
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
 
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {
@@ -36,7 +36,7 @@
                         "type": "array",
                         "minItems": 1,
                         "items": {
-                            "$ref": "#/$defs/form_element"
+                            "$ref": "#/definitions/form_element"
                         }
                     }
                 },
@@ -54,7 +54,7 @@
                         "type": "array",
                         "minItems": 1,
                         "items": {
-                            "$ref": "#/$defs/form_element"
+                            "$ref": "#/definitions/form_element"
                         }
                     }
                 },
@@ -72,7 +72,7 @@
                         "type": "array",
                         "minItems": 1,
                         "items": {
-                            "$ref": "#/$defs/form_element"
+                            "$ref": "#/definitions/form_element"
                         }
                     }
                 },
@@ -86,7 +86,7 @@
             "type": "object",
             "properties": {
                 "href": {
-                    "$ref": "#/$defs/url"
+                    "$ref": "#/definitions/url"
                 },
                 "contentType": {
                     "type": "string"

--- a/packages/assertions/assertions-td/td-vocab-forms--Thing.json
+++ b/packages/assertions/assertions-td/td-vocab-forms--Thing.json
@@ -10,7 +10,7 @@
             "type": "array",
             "minItems": 1,
             "items": {
-                "$ref": "#/$defs/form_element_root"
+                "$ref": "#/definitions/form_element_root"
             }
         }
     },
@@ -18,12 +18,12 @@
         "forms"
     ],
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "form_element_root": {
             "type": "object",
             "properties": {
                 "href": {
-                    "$ref": "#/$defs/url"
+                    "$ref": "#/definitions/url"
                 },
                 "op": {
                     "oneOf": [{

--- a/packages/assertions/assertions-td/td-vocab-hreflang--Link.json
+++ b/packages/assertions/assertions-td/td-vocab-hreflang--Link.json
@@ -8,23 +8,23 @@
         "links": {
             "type": "array",
             "items": {
-                "$ref": "#/$defs/link_element"
+                "$ref": "#/definitions/link_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "link_element": {
             "if": {
                 "type": "object",
                 "properties": {
                     "hreflang": {
                         "anyOf":[
-                          {"$ref": "#/$defs/bcp47_string"},
+                          {"$ref": "#/definitions/bcp47_string"},
                           {
                             "type":"array",
                             "items":{
-                              "$ref": "#/$defs/bcp47_string"
+                              "$ref": "#/definitions/bcp47_string"
                             }
                           }
                         ]

--- a/packages/assertions/assertions-td/td-vocab-idempotent--ActionAffordance.json
+++ b/packages/assertions/assertions-td/td-vocab-idempotent--ActionAffordance.json
@@ -9,12 +9,12 @@
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "action_element": {
             "type": "object",
             "if": {

--- a/packages/assertions/assertions-td/td-vocab-identity--PSKSecurityScheme.json
+++ b/packages/assertions/assertions-td/td-vocab-identity--PSKSecurityScheme.json
@@ -9,7 +9,7 @@
             "type": "object",
             "minProperties": 1,
             "additionalProperties": {
-                "$ref": "#/$defs/securityScheme"
+                "$ref": "#/definitions/securityScheme"
             }
         }
     },
@@ -17,7 +17,7 @@
         "securityDefinitions"
     ],
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "securityScheme": {
             "if": {
                 "type": "object",
@@ -26,7 +26,7 @@
                         "type": "string"
                     },
                     "proxy": {
-                        "$ref": "#/$defs/url"
+                        "$ref": "#/definitions/url"
                     },
                     "scheme": {
                         "type": "string",

--- a/packages/assertions/assertions-td/td-vocab-in--APIKeySecurityScheme.json
+++ b/packages/assertions/assertions-td/td-vocab-in--APIKeySecurityScheme.json
@@ -9,7 +9,7 @@
             "type": "object",
             "minProperties": 1,
             "additionalProperties": {
-                "$ref": "#/$defs/securityScheme"
+                "$ref": "#/definitions/securityScheme"
             }
         }
     },
@@ -17,7 +17,7 @@
         "securityDefinitions"
     ],
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "securityScheme": {
             "if": {
                 "type": "object",

--- a/packages/assertions/assertions-td/td-vocab-in--BasicSecurityScheme.json
+++ b/packages/assertions/assertions-td/td-vocab-in--BasicSecurityScheme.json
@@ -9,7 +9,7 @@
             "type": "object",
             "minProperties": 1,
             "additionalProperties": {
-                "$ref": "#/$defs/securityScheme"
+                "$ref": "#/definitions/securityScheme"
             }
         }
     },
@@ -17,7 +17,7 @@
         "securityDefinitions"
     ],
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "securityScheme": {
             "if": {
                 "type": "object",

--- a/packages/assertions/assertions-td/td-vocab-in--BearerSecurityScheme.json
+++ b/packages/assertions/assertions-td/td-vocab-in--BearerSecurityScheme.json
@@ -9,7 +9,7 @@
             "type": "object",
             "minProperties": 1,
             "additionalProperties": {
-                "$ref": "#/$defs/securityScheme"
+                "$ref": "#/definitions/securityScheme"
             }
         }
     },
@@ -17,7 +17,7 @@
         "securityDefinitions"
     ],
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "securityScheme": {
             "if": {
                 "type": "object",

--- a/packages/assertions/assertions-td/td-vocab-in--DigestSecurityScheme.json
+++ b/packages/assertions/assertions-td/td-vocab-in--DigestSecurityScheme.json
@@ -9,7 +9,7 @@
             "type": "object",
             "minProperties": 1,
             "additionalProperties": {
-                "$ref": "#/$defs/securityScheme"
+                "$ref": "#/definitions/securityScheme"
             }
         }
     },
@@ -17,7 +17,7 @@
         "securityDefinitions"
     ],
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "securityScheme": {
             "if": {
                 "type": "object",

--- a/packages/assertions/assertions-td/td-vocab-input--ActionAffordance.json
+++ b/packages/assertions/assertions-td/td-vocab-input--ActionAffordance.json
@@ -9,18 +9,18 @@
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "action_element": {
             "type": "object",
             "if": {
                 "properties": {
                     "input": {
-                        "$ref": "#/$defs/dataSchema"
+                        "$ref": "#/definitions/dataSchema"
                     }
                 },
                 "required": [
@@ -42,10 +42,10 @@
                     "type": "string"
                 },
                 "descriptions": {
-                    "$ref": "#/$defs/descriptions"
+                    "$ref": "#/definitions/descriptions"
                 },
                 "titles": {
-                    "$ref": "#/$defs/titles"
+                    "$ref": "#/definitions/titles"
                 },
                 "writeOnly": {
                     "type": "boolean"
@@ -56,7 +56,7 @@
                 "oneOf": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/$defs/dataSchema"
+                        "$ref": "#/definitions/dataSchema"
                     }
                 },
                 "unit": {
@@ -82,12 +82,12 @@
                 },
                 "items": {
                     "oneOf": [{
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         },
                         {
                             "type": "array",
                             "items": {
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             }
                         }
                     ]
@@ -112,7 +112,7 @@
                 },
                 "properties": {
                     "additionalProperties": {
-                        "$ref": "#/$defs/dataSchema"
+                        "$ref": "#/definitions/dataSchema"
                     }
                 },
                 "required": {

--- a/packages/assertions/assertions-td/td-vocab-items--ArraySchema.json
+++ b/packages/assertions/assertions-td/td-vocab-items--ArraySchema.json
@@ -9,24 +9,24 @@
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {
@@ -34,12 +34,12 @@
                 "properties": {
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -53,29 +53,29 @@
                 "properties": {
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "uriVariables": {
                         "type": "object",
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -87,10 +87,10 @@
             "type": "object",
             "properties": {
                 "input": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "output": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -98,13 +98,13 @@
             "type": "object",
             "properties": {
                 "subscription": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "data": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "cancellation": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -115,12 +115,12 @@
                 "properties": {
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -133,16 +133,16 @@
             "else": {
                 "properties": {
                     "description": {
-                        "$ref": "#/$defs/description"
+                        "$ref": "#/definitions/description"
                     },
                     "title": {
-                        "$ref": "#/$defs/title"
+                        "$ref": "#/definitions/title"
                     },
                     "descriptions": {
-                        "$ref": "#/$defs/descriptions"
+                        "$ref": "#/definitions/descriptions"
                     },
                     "titles": {
-                        "$ref": "#/$defs/titles"
+                        "$ref": "#/definitions/titles"
                     },
                     "writeOnly": {
                         "type": "boolean"
@@ -153,7 +153,7 @@
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "unit": {
@@ -179,12 +179,12 @@
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -209,7 +209,7 @@
                     },
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "required": {

--- a/packages/assertions/assertions-td/td-vocab-maxItems--ArraySchema.json
+++ b/packages/assertions/assertions-td/td-vocab-maxItems--ArraySchema.json
@@ -9,24 +9,24 @@
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {
@@ -45,29 +45,29 @@
                 "properties": {
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "uriVariables": {
                         "type": "object",
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -79,10 +79,10 @@
             "type": "object",
             "properties": {
                 "input": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "output": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -90,13 +90,13 @@
             "type": "object",
             "properties": {
                 "subscription": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "data": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "cancellation": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -117,16 +117,16 @@
             "else": {
                 "properties": {
                     "description": {
-                        "$ref": "#/$defs/description"
+                        "$ref": "#/definitions/description"
                     },
                     "title": {
-                        "$ref": "#/$defs/title"
+                        "$ref": "#/definitions/title"
                     },
                     "descriptions": {
-                        "$ref": "#/$defs/descriptions"
+                        "$ref": "#/definitions/descriptions"
                     },
                     "titles": {
-                        "$ref": "#/$defs/titles"
+                        "$ref": "#/definitions/titles"
                     },
                     "writeOnly": {
                         "type": "boolean"
@@ -137,7 +137,7 @@
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "unit": {
@@ -163,12 +163,12 @@
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -191,7 +191,7 @@
                     },
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "required": {

--- a/packages/assertions/assertions-td/td-vocab-maxLength--StringSchema.json
+++ b/packages/assertions/assertions-td/td-vocab-maxLength--StringSchema.json
@@ -9,35 +9,35 @@
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
-            "$ref": "#/$defs/dataSchema"
+            "$ref": "#/definitions/dataSchema"
         },
         "action_element": {
             "type": "object",
             "properties": {
                 "input": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "output": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -45,13 +45,13 @@
             "type": "object",
             "properties": {
                 "subscription": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "data": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "cancellation": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -79,29 +79,29 @@
                 "properties": {
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "uriVariables": {
                         "type": "object",
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]

--- a/packages/assertions/assertions-td/td-vocab-maximum--IntegerSchema.json
+++ b/packages/assertions/assertions-td/td-vocab-maximum--IntegerSchema.json
@@ -9,24 +9,24 @@
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {
@@ -50,29 +50,29 @@
                 "properties": {
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "uriVariables": {
                         "type": "object",
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -84,10 +84,10 @@
             "type": "object",
             "properties": {
                 "input": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "output": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -95,13 +95,13 @@
             "type": "object",
             "properties": {
                 "subscription": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "data": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "cancellation": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -127,16 +127,16 @@
             "else": {
                 "properties": {
                     "description": {
-                        "$ref": "#/$defs/description"
+                        "$ref": "#/definitions/description"
                     },
                     "title": {
-                        "$ref": "#/$defs/title"
+                        "$ref": "#/definitions/title"
                     },
                     "descriptions": {
-                        "$ref": "#/$defs/descriptions"
+                        "$ref": "#/definitions/descriptions"
                     },
                     "titles": {
-                        "$ref": "#/$defs/titles"
+                        "$ref": "#/definitions/titles"
                     },
                     "writeOnly": {
                         "type": "boolean"
@@ -147,7 +147,7 @@
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "unit": {
@@ -173,12 +173,12 @@
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -203,7 +203,7 @@
                     },
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "required": {

--- a/packages/assertions/assertions-td/td-vocab-maximum--NumberSchema.json
+++ b/packages/assertions/assertions-td/td-vocab-maximum--NumberSchema.json
@@ -9,24 +9,24 @@
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {
@@ -50,29 +50,29 @@
                 "properties": {
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "uriVariables": {
                         "type": "object",
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -84,10 +84,10 @@
             "type": "object",
             "properties": {
                 "input": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "output": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -95,13 +95,13 @@
             "type": "object",
             "properties": {
                 "subscription": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "data": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "cancellation": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -127,16 +127,16 @@
             "else": {
                 "properties": {
                     "description": {
-                        "$ref": "#/$defs/description"
+                        "$ref": "#/definitions/description"
                     },
                     "title": {
-                        "$ref": "#/$defs/title"
+                        "$ref": "#/definitions/title"
                     },
                     "descriptions": {
-                        "$ref": "#/$defs/descriptions"
+                        "$ref": "#/definitions/descriptions"
                     },
                     "titles": {
-                        "$ref": "#/$defs/titles"
+                        "$ref": "#/definitions/titles"
                     },
                     "writeOnly": {
                         "type": "boolean"
@@ -147,7 +147,7 @@
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "unit": {
@@ -173,12 +173,12 @@
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -203,7 +203,7 @@
                     },
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "required": {

--- a/packages/assertions/assertions-td/td-vocab-minItems--ArraySchema.json
+++ b/packages/assertions/assertions-td/td-vocab-minItems--ArraySchema.json
@@ -9,24 +9,24 @@
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {
@@ -45,29 +45,29 @@
                 "properties": {
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "uriVariables": {
                         "type": "object",
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -79,10 +79,10 @@
             "type": "object",
             "properties": {
                 "input": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "output": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -90,13 +90,13 @@
             "type": "object",
             "properties": {
                 "subscription": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "data": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "cancellation": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -117,16 +117,16 @@
             "else": {
                 "properties": {
                     "description": {
-                        "$ref": "#/$defs/description"
+                        "$ref": "#/definitions/description"
                     },
                     "title": {
-                        "$ref": "#/$defs/title"
+                        "$ref": "#/definitions/title"
                     },
                     "descriptions": {
-                        "$ref": "#/$defs/descriptions"
+                        "$ref": "#/definitions/descriptions"
                     },
                     "titles": {
-                        "$ref": "#/$defs/titles"
+                        "$ref": "#/definitions/titles"
                     },
                     "writeOnly": {
                         "type": "boolean"
@@ -137,7 +137,7 @@
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "unit": {
@@ -163,12 +163,12 @@
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -193,7 +193,7 @@
                     },
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "required": {

--- a/packages/assertions/assertions-td/td-vocab-minLength--StringSchema.json
+++ b/packages/assertions/assertions-td/td-vocab-minLength--StringSchema.json
@@ -9,35 +9,35 @@
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
-            "$ref": "#/$defs/dataSchema"
+            "$ref": "#/definitions/dataSchema"
         },
         "action_element": {
             "type": "object",
             "properties": {
                 "input": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "output": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -45,13 +45,13 @@
             "type": "object",
             "properties": {
                 "subscription": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "data": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "cancellation": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -79,29 +79,29 @@
                 "properties": {
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "uriVariables": {
                         "type": "object",
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]

--- a/packages/assertions/assertions-td/td-vocab-minimum--IntegerSchema.json
+++ b/packages/assertions/assertions-td/td-vocab-minimum--IntegerSchema.json
@@ -9,24 +9,24 @@
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {
@@ -50,29 +50,29 @@
                 "properties": {
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "uriVariables": {
                         "type": "object",
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -84,10 +84,10 @@
             "type": "object",
             "properties": {
                 "input": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "output": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -95,13 +95,13 @@
             "type": "object",
             "properties": {
                 "subscription": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "data": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "cancellation": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -127,16 +127,16 @@
             "else": {
                 "properties": {
                     "description": {
-                        "$ref": "#/$defs/description"
+                        "$ref": "#/definitions/description"
                     },
                     "title": {
-                        "$ref": "#/$defs/title"
+                        "$ref": "#/definitions/title"
                     },
                     "descriptions": {
-                        "$ref": "#/$defs/descriptions"
+                        "$ref": "#/definitions/descriptions"
                     },
                     "titles": {
-                        "$ref": "#/$defs/titles"
+                        "$ref": "#/definitions/titles"
                     },
                     "writeOnly": {
                         "type": "boolean"
@@ -147,7 +147,7 @@
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "unit": {
@@ -173,12 +173,12 @@
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -203,7 +203,7 @@
                     },
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "required": {

--- a/packages/assertions/assertions-td/td-vocab-minimum--NumberSchema.json
+++ b/packages/assertions/assertions-td/td-vocab-minimum--NumberSchema.json
@@ -9,24 +9,24 @@
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {
@@ -50,29 +50,29 @@
                 "properties": {
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "uriVariables": {
                         "type": "object",
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -84,10 +84,10 @@
             "type": "object",
             "properties": {
                 "input": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "output": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -95,13 +95,13 @@
             "type": "object",
             "properties": {
                 "subscription": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "data": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "cancellation": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -127,16 +127,16 @@
             "else": {
                 "properties": {
                     "description": {
-                        "$ref": "#/$defs/description"
+                        "$ref": "#/definitions/description"
                     },
                     "title": {
-                        "$ref": "#/$defs/title"
+                        "$ref": "#/definitions/title"
                     },
                     "descriptions": {
-                        "$ref": "#/$defs/descriptions"
+                        "$ref": "#/definitions/descriptions"
                     },
                     "titles": {
-                        "$ref": "#/$defs/titles"
+                        "$ref": "#/definitions/titles"
                     },
                     "writeOnly": {
                         "type": "boolean"
@@ -147,7 +147,7 @@
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "unit": {
@@ -173,12 +173,12 @@
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -203,7 +203,7 @@
                     },
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "required": {

--- a/packages/assertions/assertions-td/td-vocab-multipleOf--IntegerSchema.json
+++ b/packages/assertions/assertions-td/td-vocab-multipleOf--IntegerSchema.json
@@ -9,35 +9,35 @@
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
-            "$ref": "#/$defs/dataSchema"
+            "$ref": "#/definitions/dataSchema"
         },
         "action_element": {
             "type": "object",
             "properties": {
                 "input": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "output": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -45,13 +45,13 @@
             "type": "object",
             "properties": {
                 "subscription": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "data": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "cancellation": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -78,29 +78,29 @@
                 "properties": {
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "uriVariables": {
                         "type": "object",
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]

--- a/packages/assertions/assertions-td/td-vocab-multipleOf--NumberSchema.json
+++ b/packages/assertions/assertions-td/td-vocab-multipleOf--NumberSchema.json
@@ -9,35 +9,35 @@
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
-            "$ref": "#/$defs/dataSchema"
+            "$ref": "#/definitions/dataSchema"
         },
         "action_element": {
             "type": "object",
             "properties": {
                 "input": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "output": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -45,13 +45,13 @@
             "type": "object",
             "properties": {
                 "subscription": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "data": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "cancellation": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -78,29 +78,29 @@
                 "properties": {
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "uriVariables": {
                         "type": "object",
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]

--- a/packages/assertions/assertions-td/td-vocab-name--APIKeySecurityScheme.json
+++ b/packages/assertions/assertions-td/td-vocab-name--APIKeySecurityScheme.json
@@ -9,7 +9,7 @@
             "type": "object",
             "minProperties": 1,
             "additionalProperties": {
-                "$ref": "#/$defs/securityScheme"
+                "$ref": "#/definitions/securityScheme"
             }
         }
     },
@@ -17,7 +17,7 @@
         "securityDefinitions"
     ],
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "securityScheme": {
             "if": {
                 "type": "object",
@@ -26,7 +26,7 @@
                         "type": "string"
                     },
                     "proxy": {
-                        "$ref": "#/$defs/url"
+                        "$ref": "#/definitions/url"
                     },
                     "scheme": {
                         "type": "string",

--- a/packages/assertions/assertions-td/td-vocab-name--BasicSecurityScheme.json
+++ b/packages/assertions/assertions-td/td-vocab-name--BasicSecurityScheme.json
@@ -9,7 +9,7 @@
             "type": "object",
             "minProperties": 1,
             "additionalProperties": {
-                "$ref": "#/$defs/securityScheme"
+                "$ref": "#/definitions/securityScheme"
             }
         }
     },
@@ -17,7 +17,7 @@
         "securityDefinitions"
     ],
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "securityScheme": {
             "if": {
                 "type": "object",
@@ -26,7 +26,7 @@
                         "type": "string"
                     },
                     "proxy": {
-                        "$ref": "#/$defs/url"
+                        "$ref": "#/definitions/url"
                     },
                     "scheme": {
                         "type": "string",

--- a/packages/assertions/assertions-td/td-vocab-name--BearerSecurityScheme.json
+++ b/packages/assertions/assertions-td/td-vocab-name--BearerSecurityScheme.json
@@ -9,7 +9,7 @@
             "type": "object",
             "minProperties": 1,
             "additionalProperties": {
-                "$ref": "#/$defs/securityScheme"
+                "$ref": "#/definitions/securityScheme"
             }
         }
     },
@@ -17,7 +17,7 @@
         "securityDefinitions"
     ],
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "securityScheme": {
             "if": {
                 "type": "object",
@@ -26,7 +26,7 @@
                         "type": "string"
                     },
                     "proxy": {
-                        "$ref": "#/$defs/url"
+                        "$ref": "#/definitions/url"
                     },
                     "scheme": {
                         "type": "string",
@@ -35,7 +35,7 @@
                         ]
                     },
                     "authorization": {
-                        "$ref": "#/$defs/url"
+                        "$ref": "#/definitions/url"
                     },
                     "alg": {
                         "type": "string"

--- a/packages/assertions/assertions-td/td-vocab-name--DigestSecurityScheme.json
+++ b/packages/assertions/assertions-td/td-vocab-name--DigestSecurityScheme.json
@@ -9,7 +9,7 @@
             "type": "object",
             "minProperties": 1,
             "additionalProperties": {
-                "$ref": "#/$defs/securityScheme"
+                "$ref": "#/definitions/securityScheme"
             }
         }
     },
@@ -17,7 +17,7 @@
         "securityDefinitions"
     ],
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "securityScheme": {
             "if": {
                 "type": "object",
@@ -26,7 +26,7 @@
                         "type": "string"
                     },
                     "proxy": {
-                        "$ref": "#/$defs/url"
+                        "$ref": "#/definitions/url"
                     },
                     "scheme": {
                         "type": "string",

--- a/packages/assertions/assertions-td/td-vocab-observable--PropertyAffordance.json
+++ b/packages/assertions/assertions-td/td-vocab-observable--PropertyAffordance.json
@@ -9,12 +9,12 @@
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {

--- a/packages/assertions/assertions-td/td-vocab-oneOf--ComboSecurityScheme.json
+++ b/packages/assertions/assertions-td/td-vocab-oneOf--ComboSecurityScheme.json
@@ -9,7 +9,7 @@
             "type": "object",
             "minProperties": 1,
             "additionalProperties": {
-                "$ref": "#/$defs/comboSecurity_element"
+                "$ref": "#/definitions/comboSecurity_element"
             }
         }
     },
@@ -18,7 +18,7 @@
     ],
     "additionalProperties": true,
 
-    "$defs": {
+    "definitions": {
         "comboSecurity_element": {
             "type": "object",
             "if": {

--- a/packages/assertions/assertions-td/td-vocab-oneOf--DataSchema.json
+++ b/packages/assertions/assertions-td/td-vocab-oneOf--DataSchema.json
@@ -9,25 +9,25 @@
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
 
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {
@@ -36,7 +36,7 @@
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     }
                 }
@@ -48,29 +48,29 @@
                 "properties": {
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "uriVariables": {
                         "type": "object",
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -82,10 +82,10 @@
             "type": "object",
             "properties": {
                 "input": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "output": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -93,13 +93,13 @@
             "type": "object",
             "properties": {
                 "subscription": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "data": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "cancellation": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -111,7 +111,7 @@
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     }
                 }
@@ -122,16 +122,16 @@
             "else": {
                 "properties": {
                     "description": {
-                        "$ref": "#/$defs/description"
+                        "$ref": "#/definitions/description"
                     },
                     "title": {
-                        "$ref": "#/$defs/title"
+                        "$ref": "#/definitions/title"
                     },
                     "descriptions": {
-                        "$ref": "#/$defs/descriptions"
+                        "$ref": "#/definitions/descriptions"
                     },
                     "titles": {
-                        "$ref": "#/$defs/titles"
+                        "$ref": "#/definitions/titles"
                     },
                     "writeOnly": {
                         "type": "boolean"
@@ -142,7 +142,7 @@
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "unit": {
@@ -168,12 +168,12 @@
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -198,7 +198,7 @@
                     },
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "required": {

--- a/packages/assertions/assertions-td/td-vocab-op--Form_cancelaction.json
+++ b/packages/assertions/assertions-td/td-vocab-op--Form_cancelaction.json
@@ -10,32 +10,32 @@
             "type": "array",
             "minItems": 1,
             "items": {
-                "$ref": "#/$defs/form_element"
+                "$ref": "#/definitions/form_element"
             }
         },
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
 
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
 
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "properties": {
@@ -43,7 +43,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element"
+                        "$ref": "#/definitions/form_element"
                     }
                 }
             },
@@ -59,7 +59,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element"
+                        "$ref": "#/definitions/form_element"
                     }
                 }
             },
@@ -75,7 +75,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element"
+                        "$ref": "#/definitions/form_element"
                     }
                 }
             },

--- a/packages/assertions/assertions-td/td-vocab-op--Form_invokeaction.json
+++ b/packages/assertions/assertions-td/td-vocab-op--Form_invokeaction.json
@@ -10,32 +10,32 @@
             "type": "array",
             "minItems": 1,
             "items": {
-                "$ref": "#/$defs/form_element"
+                "$ref": "#/definitions/form_element"
             }
         },
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
 
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
 
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "properties": {
@@ -43,7 +43,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element"
+                        "$ref": "#/definitions/form_element"
                     }
                 }
             },
@@ -59,7 +59,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element"
+                        "$ref": "#/definitions/form_element"
                     }
                 }
             },
@@ -75,7 +75,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element"
+                        "$ref": "#/definitions/form_element"
                     }
                 }
             },

--- a/packages/assertions/assertions-td/td-vocab-op--Form_observeallproperties.json
+++ b/packages/assertions/assertions-td/td-vocab-op--Form_observeallproperties.json
@@ -10,18 +10,18 @@
             "type": "array",
             "minItems": 1,
             "items": {
-                "$ref": "#/$defs/form_element_root"
+                "$ref": "#/definitions/form_element_root"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "form_element_root": {
             "if": {
                 "type": "object",
                 "properties": {
                     "href": {
-                        "$ref": "#/$defs/url"
+                        "$ref": "#/definitions/url"
                     },
                     "op": {
                         "oneOf": [{

--- a/packages/assertions/assertions-td/td-vocab-op--Form_observeproperty.json
+++ b/packages/assertions/assertions-td/td-vocab-op--Form_observeproperty.json
@@ -10,32 +10,32 @@
             "type": "array",
             "minItems": 1,
             "items": {
-                "$ref": "#/$defs/form_element"
+                "$ref": "#/definitions/form_element"
             }
         },
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
 
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
 
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "properties": {
@@ -43,7 +43,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element"
+                        "$ref": "#/definitions/form_element"
                     }
                 }
             },
@@ -59,7 +59,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element"
+                        "$ref": "#/definitions/form_element"
                     }
                 }
             },
@@ -75,7 +75,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element"
+                        "$ref": "#/definitions/form_element"
                     }
                 }
             },

--- a/packages/assertions/assertions-td/td-vocab-op--Form_queryaction.json
+++ b/packages/assertions/assertions-td/td-vocab-op--Form_queryaction.json
@@ -10,32 +10,32 @@
             "type": "array",
             "minItems": 1,
             "items": {
-                "$ref": "#/$defs/form_element"
+                "$ref": "#/definitions/form_element"
             }
         },
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
 
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
 
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "properties": {
@@ -43,7 +43,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element"
+                        "$ref": "#/definitions/form_element"
                     }
                 }
             },
@@ -59,7 +59,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element"
+                        "$ref": "#/definitions/form_element"
                     }
                 }
             },
@@ -75,7 +75,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element"
+                        "$ref": "#/definitions/form_element"
                     }
                 }
             },

--- a/packages/assertions/assertions-td/td-vocab-op--Form_queryallactions.json
+++ b/packages/assertions/assertions-td/td-vocab-op--Form_queryallactions.json
@@ -10,18 +10,18 @@
             "type": "array",
             "minItems": 1,
             "items": {
-                "$ref": "#/$defs/form_element_root"
+                "$ref": "#/definitions/form_element_root"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "form_element_root": {
             "if": {
                 "type": "object",
                 "properties": {
                     "href": {
-                        "$ref": "#/$defs/url"
+                        "$ref": "#/definitions/url"
                     },
                     "op": {
                         "oneOf": [{

--- a/packages/assertions/assertions-td/td-vocab-op--Form_readallproperties.json
+++ b/packages/assertions/assertions-td/td-vocab-op--Form_readallproperties.json
@@ -10,18 +10,18 @@
             "type": "array",
             "minItems": 1,
             "items": {
-                "$ref": "#/$defs/form_element_root"
+                "$ref": "#/definitions/form_element_root"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "form_element_root": {
             "if": {
                 "type": "object",
                 "properties": {
                     "href": {
-                        "$ref": "#/$defs/url"
+                        "$ref": "#/definitions/url"
                     },
                     "op": {
                         "oneOf": [{

--- a/packages/assertions/assertions-td/td-vocab-op--Form_readmultipleproperties.json
+++ b/packages/assertions/assertions-td/td-vocab-op--Form_readmultipleproperties.json
@@ -10,18 +10,18 @@
             "type": "array",
             "minItems": 1,
             "items": {
-                "$ref": "#/$defs/form_element_root"
+                "$ref": "#/definitions/form_element_root"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "form_element_root": {
             "if": {
                 "type": "object",
                 "properties": {
                     "href": {
-                        "$ref": "#/$defs/url"
+                        "$ref": "#/definitions/url"
                     },
                     "op": {
                         "oneOf": [{

--- a/packages/assertions/assertions-td/td-vocab-op--Form_readproperty.json
+++ b/packages/assertions/assertions-td/td-vocab-op--Form_readproperty.json
@@ -9,12 +9,12 @@
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "properties": {
@@ -22,7 +22,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element"
+                        "$ref": "#/definitions/form_element"
                     }
                 }
             },

--- a/packages/assertions/assertions-td/td-vocab-op--Form_subscribeallevents.json
+++ b/packages/assertions/assertions-td/td-vocab-op--Form_subscribeallevents.json
@@ -10,18 +10,18 @@
             "type": "array",
             "minItems": 1,
             "items": {
-                "$ref": "#/$defs/form_element_root"
+                "$ref": "#/definitions/form_element_root"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "form_element_root": {
             "if": {
                 "type": "object",
                 "properties": {
                     "href": {
-                        "$ref": "#/$defs/url"
+                        "$ref": "#/definitions/url"
                     },
                     "op": {
                         "oneOf": [{

--- a/packages/assertions/assertions-td/td-vocab-op--Form_subscribeevent.json
+++ b/packages/assertions/assertions-td/td-vocab-op--Form_subscribeevent.json
@@ -10,32 +10,32 @@
             "type": "array",
             "minItems": 1,
             "items": {
-                "$ref": "#/$defs/form_element"
+                "$ref": "#/definitions/form_element"
             }
         },
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
 
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
 
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "properties": {
@@ -43,7 +43,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element"
+                        "$ref": "#/definitions/form_element"
                     }
                 }
             },
@@ -59,7 +59,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element"
+                        "$ref": "#/definitions/form_element"
                     }
                 }
             },
@@ -75,7 +75,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element"
+                        "$ref": "#/definitions/form_element"
                     }
                 }
             },

--- a/packages/assertions/assertions-td/td-vocab-op--Form_unobserveallproperties.json
+++ b/packages/assertions/assertions-td/td-vocab-op--Form_unobserveallproperties.json
@@ -10,18 +10,18 @@
             "type": "array",
             "minItems": 1,
             "items": {
-                "$ref": "#/$defs/form_element_root"
+                "$ref": "#/definitions/form_element_root"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "form_element_root": {
             "if": {
                 "type": "object",
                 "properties": {
                     "href": {
-                        "$ref": "#/$defs/url"
+                        "$ref": "#/definitions/url"
                     },
                     "op": {
                         "oneOf": [{

--- a/packages/assertions/assertions-td/td-vocab-op--Form_unobserveproperty.json
+++ b/packages/assertions/assertions-td/td-vocab-op--Form_unobserveproperty.json
@@ -10,32 +10,32 @@
             "type": "array",
             "minItems": 1,
             "items": {
-                "$ref": "#/$defs/form_element"
+                "$ref": "#/definitions/form_element"
             }
         },
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
 
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
 
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "properties": {
@@ -43,7 +43,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element"
+                        "$ref": "#/definitions/form_element"
                     }
                 }
             },
@@ -59,7 +59,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element"
+                        "$ref": "#/definitions/form_element"
                     }
                 }
             },
@@ -75,7 +75,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element"
+                        "$ref": "#/definitions/form_element"
                     }
                 }
             },

--- a/packages/assertions/assertions-td/td-vocab-op--Form_unsubscribeallevents.json
+++ b/packages/assertions/assertions-td/td-vocab-op--Form_unsubscribeallevents.json
@@ -10,18 +10,18 @@
             "type": "array",
             "minItems": 1,
             "items": {
-                "$ref": "#/$defs/form_element_root"
+                "$ref": "#/definitions/form_element_root"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "form_element_root": {
             "if": {
                 "type": "object",
                 "properties": {
                     "href": {
-                        "$ref": "#/$defs/url"
+                        "$ref": "#/definitions/url"
                     },
                     "op": {
                         "oneOf": [{

--- a/packages/assertions/assertions-td/td-vocab-op--Form_unsubscribeevent.json
+++ b/packages/assertions/assertions-td/td-vocab-op--Form_unsubscribeevent.json
@@ -10,32 +10,32 @@
             "type": "array",
             "minItems": 1,
             "items": {
-                "$ref": "#/$defs/form_element"
+                "$ref": "#/definitions/form_element"
             }
         },
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
 
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
 
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "properties": {
@@ -43,7 +43,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element"
+                        "$ref": "#/definitions/form_element"
                     }
                 }
             },
@@ -59,7 +59,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element"
+                        "$ref": "#/definitions/form_element"
                     }
                 }
             },
@@ -75,7 +75,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element"
+                        "$ref": "#/definitions/form_element"
                     }
                 }
             },

--- a/packages/assertions/assertions-td/td-vocab-op--Form_writeallproperties.json
+++ b/packages/assertions/assertions-td/td-vocab-op--Form_writeallproperties.json
@@ -10,18 +10,18 @@
             "type": "array",
             "minItems": 1,
             "items": {
-                "$ref": "#/$defs/form_element_root"
+                "$ref": "#/definitions/form_element_root"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "form_element_root": {
             "if": {
                 "type": "object",
                 "properties": {
                     "href": {
-                        "$ref": "#/$defs/url"
+                        "$ref": "#/definitions/url"
                     },
                     "op": {
                         "oneOf": [{

--- a/packages/assertions/assertions-td/td-vocab-op--Form_writemultipleproperties.json
+++ b/packages/assertions/assertions-td/td-vocab-op--Form_writemultipleproperties.json
@@ -10,18 +10,18 @@
             "type": "array",
             "minItems": 1,
             "items": {
-                "$ref": "#/$defs/form_element_root"
+                "$ref": "#/definitions/form_element_root"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "form_element_root": {
             "if": {
                 "type": "object",
                 "properties": {
                     "href": {
-                        "$ref": "#/$defs/url"
+                        "$ref": "#/definitions/url"
                     },
                     "op": {
                         "oneOf": [{

--- a/packages/assertions/assertions-td/td-vocab-op--Form_writeproperty.json
+++ b/packages/assertions/assertions-td/td-vocab-op--Form_writeproperty.json
@@ -9,12 +9,12 @@
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "properties": {
@@ -22,7 +22,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element"
+                        "$ref": "#/definitions/form_element"
                     }
                 }
             },

--- a/packages/assertions/assertions-td/td-vocab-output--ActionAffordance.json
+++ b/packages/assertions/assertions-td/td-vocab-output--ActionAffordance.json
@@ -9,12 +9,12 @@
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "action_element": {
             "type": "object",
             "if": {
@@ -38,10 +38,10 @@
                     "type": "string"
                 },
                 "descriptions": {
-                    "$ref": "#/$defs/descriptions"
+                    "$ref": "#/definitions/descriptions"
                 },
                 "titles": {
-                    "$ref": "#/$defs/titles"
+                    "$ref": "#/definitions/titles"
                 },
                 "writeOnly": {
                     "type": "boolean"
@@ -52,7 +52,7 @@
                 "oneOf": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/$defs/dataSchema"
+                        "$ref": "#/definitions/dataSchema"
                     }
                 },
                 "unit": {
@@ -78,12 +78,12 @@
                 },
                 "items": {
                     "oneOf": [{
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         },
                         {
                             "type": "array",
                             "items": {
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             }
                         }
                     ]
@@ -108,7 +108,7 @@
                 },
                 "properties": {
                     "additionalProperties": {
-                        "$ref": "#/$defs/dataSchema"
+                        "$ref": "#/definitions/dataSchema"
                     }
                 },
                 "required": {

--- a/packages/assertions/assertions-td/td-vocab-pattern--StringSchema.json
+++ b/packages/assertions/assertions-td/td-vocab-pattern--StringSchema.json
@@ -9,35 +9,35 @@
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
-            "$ref": "#/$defs/dataSchema"
+            "$ref": "#/definitions/dataSchema"
         },
         "action_element": {
             "type": "object",
             "properties": {
                 "input": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "output": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -45,13 +45,13 @@
             "type": "object",
             "properties": {
                 "subscription": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "data": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "cancellation": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -77,16 +77,16 @@
             "else": {
                 "properties": {
                     "description": {
-                        "$ref": "#/$defs/description"
+                        "$ref": "#/definitions/description"
                     },
                     "title": {
-                        "$ref": "#/$defs/title"
+                        "$ref": "#/definitions/title"
                     },
                     "descriptions": {
-                        "$ref": "#/$defs/descriptions"
+                        "$ref": "#/definitions/descriptions"
                     },
                     "titles": {
-                        "$ref": "#/$defs/titles"
+                        "$ref": "#/definitions/titles"
                     },
                     "writeOnly": {
                         "type": "boolean"
@@ -97,7 +97,7 @@
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "unit": {
@@ -123,12 +123,12 @@
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -153,7 +153,7 @@
                     },
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "required": {

--- a/packages/assertions/assertions-td/td-vocab-profile--Thing.json
+++ b/packages/assertions/assertions-td/td-vocab-profile--Thing.json
@@ -8,18 +8,18 @@
         "profile": {
             "oneof": [
                 {
-                    "$ref": "#/$defs/anyUri"
+                    "$ref": "#/definitions/anyUri"
                 },
                 {
                     "type": "array",
                     "items": {
-                        "$ref": "#/$defs/anyUri"
+                        "$ref": "#/definitions/anyUri"
                     }
                 }
             ]
         }
     },
-    "$defs": {
+    "definitions": {
         "anyUri": {
             "type": "string",
             "format": "iri-reference"

--- a/packages/assertions/assertions-td/td-vocab-properties--ObjectSchema.json
+++ b/packages/assertions/assertions-td/td-vocab-properties--ObjectSchema.json
@@ -1,6 +1,6 @@
 {
     "title": "td-vocab-properties--ObjectSchema",
-    "description": "properties: Data schema nested $defs. MAY be included. Type: DataSchema.",
+    "description": "properties: Data schema nested definitions. MAY be included. Type: DataSchema.",
     "$schema": "http://json-schema.org/draft-07/schema#",
     "is-complex": true,
     "also": ["td-data-schema_properties", "td-data-schema-objects"],
@@ -9,24 +9,24 @@
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {
@@ -34,7 +34,7 @@
                 "properties": {
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     }
                 }
@@ -46,29 +46,29 @@
                 "properties": {
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "uriVariables": {
                         "type": "object",
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -80,10 +80,10 @@
             "type": "object",
             "properties": {
                 "input": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "output": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -91,13 +91,13 @@
             "type": "object",
             "properties": {
                 "subscription": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "data": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "cancellation": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -108,7 +108,7 @@
                 "properties": {
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     }
                 }
@@ -119,16 +119,16 @@
             "else": {
                 "properties": {
                     "description": {
-                        "$ref": "#/$defs/description"
+                        "$ref": "#/definitions/description"
                     },
                     "title": {
-                        "$ref": "#/$defs/title"
+                        "$ref": "#/definitions/title"
                     },
                     "descriptions": {
-                        "$ref": "#/$defs/descriptions"
+                        "$ref": "#/definitions/descriptions"
                     },
                     "titles": {
-                        "$ref": "#/$defs/titles"
+                        "$ref": "#/definitions/titles"
                     },
                     "writeOnly": {
                         "type": "boolean"
@@ -139,7 +139,7 @@
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "unit": {
@@ -165,12 +165,12 @@
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -195,7 +195,7 @@
                     },
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "required": {

--- a/packages/assertions/assertions-td/td-vocab-proxy--SecurityScheme.json
+++ b/packages/assertions/assertions-td/td-vocab-proxy--SecurityScheme.json
@@ -9,7 +9,7 @@
             "type": "object",
             "minProperties": 1,
             "additionalProperties": {
-                "$ref": "#/$defs/securityScheme"
+                "$ref": "#/definitions/securityScheme"
             }
         }
     },
@@ -17,13 +17,13 @@
         "securityDefinitions"
     ],
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "securityScheme": {
             "type": "object",
             "if": {
                 "properties": {
                     "proxy": {
-                        "$ref": "#/$defs/url"
+                        "$ref": "#/definitions/url"
                     }
                 },
                 "required": ["proxy"]

--- a/packages/assertions/assertions-td/td-vocab-qop--DigestSecurityScheme.json
+++ b/packages/assertions/assertions-td/td-vocab-qop--DigestSecurityScheme.json
@@ -9,7 +9,7 @@
             "type": "object",
             "minProperties": 1,
             "additionalProperties": {
-                "$ref": "#/$defs/securityScheme"
+                "$ref": "#/definitions/securityScheme"
             }
         }
     },
@@ -17,7 +17,7 @@
         "securityDefinitions"
     ],
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "securityScheme": {
             "if": {
                 "oneOf": [{
@@ -27,7 +27,7 @@
                             "type": "string"
                         },
                         "proxy": {
-                            "$ref": "#/$defs/url"
+                            "$ref": "#/definitions/url"
                         },
                         "scheme": {
                             "type": "string",

--- a/packages/assertions/assertions-td/td-vocab-readOnly--DataSchema.json
+++ b/packages/assertions/assertions-td/td-vocab-readOnly--DataSchema.json
@@ -9,24 +9,24 @@
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {
@@ -44,29 +44,29 @@
                 "properties": {
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "uriVariables": {
                         "type": "object",
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -78,10 +78,10 @@
             "type": "object",
             "properties": {
                 "input": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "output": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -89,13 +89,13 @@
             "type": "object",
             "properties": {
                 "subscription": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "data": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "cancellation": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -115,16 +115,16 @@
             "else": {
                 "properties": {
                     "description": {
-                        "$ref": "#/$defs/description"
+                        "$ref": "#/definitions/description"
                     },
                     "title": {
-                        "$ref": "#/$defs/title"
+                        "$ref": "#/definitions/title"
                     },
                     "descriptions": {
-                        "$ref": "#/$defs/descriptions"
+                        "$ref": "#/definitions/descriptions"
                     },
                     "titles": {
-                        "$ref": "#/$defs/titles"
+                        "$ref": "#/definitions/titles"
                     },
                     "writeOnly": {
                         "type": "boolean"
@@ -135,7 +135,7 @@
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "unit": {
@@ -161,12 +161,12 @@
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -189,7 +189,7 @@
                     },
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "required": {

--- a/packages/assertions/assertions-td/td-vocab-refresh--OAuth2SecurityScheme.json
+++ b/packages/assertions/assertions-td/td-vocab-refresh--OAuth2SecurityScheme.json
@@ -9,7 +9,7 @@
             "type": "object",
             "minProperties": 1,
             "additionalProperties": {
-                "$ref": "#/$defs/securityScheme"
+                "$ref": "#/definitions/securityScheme"
             }
         }
     },
@@ -17,7 +17,7 @@
         "securityDefinitions"
     ],
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "securityScheme": {
             "if": {
                 "oneOf": [{
@@ -27,7 +27,7 @@
                             "type": "string"
                         },
                         "proxy": {
-                            "$ref": "#/$defs/url"
+                            "$ref": "#/definitions/url"
                         },
                         "scheme": {
                             "type": "string",
@@ -36,13 +36,13 @@
                             ]
                         },
                         "authorization": {
-                            "$ref": "#/$defs/url"
+                            "$ref": "#/definitions/url"
                         },
                         "token": {
-                            "$ref": "#/$defs/url"
+                            "$ref": "#/definitions/url"
                         },
                         "refresh": {
-                            "$ref": "#/$defs/url"
+                            "$ref": "#/definitions/url"
                         },
                         "scopes": {
                             "type": "array",

--- a/packages/assertions/assertions-td/td-vocab-rel--Link.json
+++ b/packages/assertions/assertions-td/td-vocab-rel--Link.json
@@ -8,12 +8,12 @@
         "links": {
             "type": "array",
             "items": {
-                "$ref": "#/$defs/link_element"
+                "$ref": "#/definitions/link_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "link_element": {
             "if": {
                 "type": "object",

--- a/packages/assertions/assertions-td/td-vocab-required--ObjectSchema.json
+++ b/packages/assertions/assertions-td/td-vocab-required--ObjectSchema.json
@@ -9,24 +9,24 @@
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {
@@ -47,29 +47,29 @@
                 "properties": {
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "uriVariables": {
                         "type": "object",
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -81,10 +81,10 @@
             "type": "object",
             "properties": {
                 "input": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "output": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -92,13 +92,13 @@
             "type": "object",
             "properties": {
                 "subscription": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "data": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "cancellation": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -121,16 +121,16 @@
             "else": {
                 "properties": {
                     "description": {
-                        "$ref": "#/$defs/description"
+                        "$ref": "#/definitions/description"
                     },
                     "title": {
-                        "$ref": "#/$defs/title"
+                        "$ref": "#/definitions/title"
                     },
                     "descriptions": {
-                        "$ref": "#/$defs/descriptions"
+                        "$ref": "#/definitions/descriptions"
                     },
                     "titles": {
-                        "$ref": "#/$defs/titles"
+                        "$ref": "#/definitions/titles"
                     },
                     "writeOnly": {
                         "type": "boolean"
@@ -141,7 +141,7 @@
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "unit": {
@@ -167,12 +167,12 @@
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -197,7 +197,7 @@
                     },
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "required": {

--- a/packages/assertions/assertions-td/td-vocab-response--Form.json
+++ b/packages/assertions/assertions-td/td-vocab-response--Form.json
@@ -10,32 +10,32 @@
             "type": "array",
             "minItems": 1,
             "items": {
-                "$ref": "#/$defs/form_element"
+                "$ref": "#/definitions/form_element"
             }
         },
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
 
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
 
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "properties": {
@@ -43,7 +43,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element"
+                        "$ref": "#/definitions/form_element"
                     }
                 }
             },
@@ -59,7 +59,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element"
+                        "$ref": "#/definitions/form_element"
                     }
                 }
             },
@@ -75,7 +75,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element"
+                        "$ref": "#/definitions/form_element"
                     }
                 }
             },

--- a/packages/assertions/assertions-td/td-vocab-safe--ActionAffordance.json
+++ b/packages/assertions/assertions-td/td-vocab-safe--ActionAffordance.json
@@ -9,12 +9,12 @@
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "action_element": {
             "type": "object",
             "if": {

--- a/packages/assertions/assertions-td/td-vocab-schema--AdditionalExpectedResponse.json
+++ b/packages/assertions/assertions-td/td-vocab-schema--AdditionalExpectedResponse.json
@@ -10,30 +10,30 @@
             "type": "array",
             "minItems": 1,
             "items": {
-                "$ref": "#/$defs/form_element"
+                "$ref": "#/definitions/form_element"
             }
         },
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
 
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "properties": {
@@ -41,7 +41,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element"
+                        "$ref": "#/definitions/form_element"
                     }
                 }
             },
@@ -57,7 +57,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element"
+                        "$ref": "#/definitions/form_element"
                     }
                 }
             },
@@ -73,7 +73,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element"
+                        "$ref": "#/definitions/form_element"
                     }
                 }
             },
@@ -90,12 +90,12 @@
                      "additionalResponses": {
                         "oneOff": [
                             {
-                                "$ref": "#/$defs/additionalResponse_element"
+                                "$ref": "#/definitions/additionalResponse_element"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/additionalResponse_element"
+                                    "$ref": "#/definitions/additionalResponse_element"
                                 }
                             }
                         ]

--- a/packages/assertions/assertions-td/td-vocab-scheme--SecurityScheme_apikey.json
+++ b/packages/assertions/assertions-td/td-vocab-scheme--SecurityScheme_apikey.json
@@ -10,7 +10,7 @@
             "type": "object",
             "minProperties": 1,
             "additionalProperties": {
-                "$ref": "#/$defs/securityScheme"
+                "$ref": "#/definitions/securityScheme"
             }
         }
     },
@@ -18,7 +18,7 @@
         "securityDefinitions"
     ],
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "securityScheme": {
             "if": {
                 "type": "object",

--- a/packages/assertions/assertions-td/td-vocab-scheme--SecurityScheme_auto.json
+++ b/packages/assertions/assertions-td/td-vocab-scheme--SecurityScheme_auto.json
@@ -10,7 +10,7 @@
             "type": "object",
             "minProperties": 1,
             "additionalProperties": {
-                "$ref": "#/$defs/securityScheme"
+                "$ref": "#/definitions/securityScheme"
             }
         }
     },
@@ -18,7 +18,7 @@
         "securityDefinitions"
     ],
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "securityScheme": {
             "if": {
                 "type": "object",

--- a/packages/assertions/assertions-td/td-vocab-scheme--SecurityScheme_basic.json
+++ b/packages/assertions/assertions-td/td-vocab-scheme--SecurityScheme_basic.json
@@ -10,7 +10,7 @@
             "type": "object",
             "minProperties": 1,
             "additionalProperties": {
-                "$ref": "#/$defs/securityScheme"
+                "$ref": "#/definitions/securityScheme"
             }
         }
     },
@@ -18,7 +18,7 @@
         "securityDefinitions"
     ],
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "securityScheme": {
             "if": {
                 "type": "object",

--- a/packages/assertions/assertions-td/td-vocab-scheme--SecurityScheme_bearer.json
+++ b/packages/assertions/assertions-td/td-vocab-scheme--SecurityScheme_bearer.json
@@ -10,7 +10,7 @@
             "type": "object",
             "minProperties": 1,
             "additionalProperties": {
-                "$ref": "#/$defs/securityScheme"
+                "$ref": "#/definitions/securityScheme"
             }
         }
     },
@@ -18,7 +18,7 @@
         "securityDefinitions"
     ],
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "securityScheme": {
             "if": {
                 "type": "object",

--- a/packages/assertions/assertions-td/td-vocab-scheme--SecurityScheme_digest.json
+++ b/packages/assertions/assertions-td/td-vocab-scheme--SecurityScheme_digest.json
@@ -10,7 +10,7 @@
             "type": "object",
             "minProperties": 1,
             "additionalProperties": {
-                "$ref": "#/$defs/securityScheme"
+                "$ref": "#/definitions/securityScheme"
             }
         }
     },
@@ -18,7 +18,7 @@
         "securityDefinitions"
     ],
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "securityScheme": {
             "if": {
                 "type": "object",

--- a/packages/assertions/assertions-td/td-vocab-scheme--SecurityScheme_nosec.json
+++ b/packages/assertions/assertions-td/td-vocab-scheme--SecurityScheme_nosec.json
@@ -9,7 +9,7 @@
             "type": "object",
             "minProperties": 1,
             "additionalProperties": {
-                "$ref": "#/$defs/securityScheme"
+                "$ref": "#/definitions/securityScheme"
             }
         }
     },
@@ -17,7 +17,7 @@
         "securityDefinitions"
     ],
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "securityScheme": {
             "if": {
                 "type": "object",

--- a/packages/assertions/assertions-td/td-vocab-scheme--SecurityScheme_oauth2.json
+++ b/packages/assertions/assertions-td/td-vocab-scheme--SecurityScheme_oauth2.json
@@ -10,7 +10,7 @@
             "type": "object",
             "minProperties": 1,
             "additionalProperties": {
-                "$ref": "#/$defs/securityScheme"
+                "$ref": "#/definitions/securityScheme"
             }
         }
     },
@@ -18,7 +18,7 @@
         "securityDefinitions"
     ],
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "securityScheme": {
             "if": {
                 "type": "object",

--- a/packages/assertions/assertions-td/td-vocab-scheme--SecurityScheme_psk.json
+++ b/packages/assertions/assertions-td/td-vocab-scheme--SecurityScheme_psk.json
@@ -10,7 +10,7 @@
             "type": "object",
             "minProperties": 1,
             "additionalProperties": {
-                "$ref": "#/$defs/securityScheme"
+                "$ref": "#/definitions/securityScheme"
             }
         }
     },
@@ -18,7 +18,7 @@
         "securityDefinitions"
     ],
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "securityScheme": {
             "if": {
                 "type": "object",

--- a/packages/assertions/assertions-td/td-vocab-scopes--Form.json
+++ b/packages/assertions/assertions-td/td-vocab-scopes--Form.json
@@ -9,30 +9,30 @@
             "type": "array",
             "minItems": 1,
             "items": {
-                "$ref": "#/$defs/form_element"
+                "$ref": "#/definitions/form_element"
             }
         },
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "properties": {
@@ -40,7 +40,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element"
+                        "$ref": "#/definitions/form_element"
                     }
                 }
             },
@@ -55,7 +55,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element"
+                        "$ref": "#/definitions/form_element"
                     }
                 }
             },
@@ -70,7 +70,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element"
+                        "$ref": "#/definitions/form_element"
                     }
                 }
             },

--- a/packages/assertions/assertions-td/td-vocab-scopes--OAuth2SecurityScheme.json
+++ b/packages/assertions/assertions-td/td-vocab-scopes--OAuth2SecurityScheme.json
@@ -9,7 +9,7 @@
             "type": "object",
             "minProperties": 1,
             "additionalProperties": {
-                "$ref": "#/$defs/securityScheme"
+                "$ref": "#/definitions/securityScheme"
             }
         }
     },
@@ -17,7 +17,7 @@
         "securityDefinitions"
     ],
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "securityScheme": {
             "if": {
                     "type": "object",
@@ -26,7 +26,7 @@
                             "type": "string"
                         },
                         "proxy": {
-                            "$ref": "#/$defs/url"
+                            "$ref": "#/definitions/url"
                         },
                         "scheme": {
                             "type": "string",
@@ -35,13 +35,13 @@
                             ]
                         },
                         "authorization": {
-                            "$ref": "#/$defs/url"
+                            "$ref": "#/definitions/url"
                         },
                         "token": {
-                            "$ref": "#/$defs/url"
+                            "$ref": "#/definitions/url"
                         },
                         "refresh": {
-                            "$ref": "#/$defs/url"
+                            "$ref": "#/definitions/url"
                         },
                         "scopes": {
                             "type": "array",

--- a/packages/assertions/assertions-td/td-vocab-security--Form.json
+++ b/packages/assertions/assertions-td/td-vocab-security--Form.json
@@ -10,30 +10,30 @@
             "type": "array",
             "minItems": 1,
             "items": {
-                "$ref": "#/$defs/form_element"
+                "$ref": "#/definitions/form_element"
             }
         },
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "properties": {
@@ -41,7 +41,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element"
+                        "$ref": "#/definitions/form_element"
                     }
                 }
             },
@@ -57,7 +57,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element"
+                        "$ref": "#/definitions/form_element"
                     }
                 }
             },
@@ -73,7 +73,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element"
+                        "$ref": "#/definitions/form_element"
                     }
                 }
             },

--- a/packages/assertions/assertions-td/td-vocab-sizes--Link.json
+++ b/packages/assertions/assertions-td/td-vocab-sizes--Link.json
@@ -8,12 +8,12 @@
         "links": {
             "type": "array",
             "items": {
-                "$ref": "#/$defs/link_element"
+                "$ref": "#/definitions/link_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "link_element": {
             "if": {
                 "type": "object",

--- a/packages/assertions/assertions-td/td-vocab-subprotocol--Form.json
+++ b/packages/assertions/assertions-td/td-vocab-subprotocol--Form.json
@@ -9,32 +9,32 @@
             "type": "array",
             "minItems": 1,
             "items": {
-                "$ref": "#/$defs/form_element"
+                "$ref": "#/definitions/form_element"
             }
         },
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
 
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
 
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "properties": {
@@ -42,7 +42,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element"
+                        "$ref": "#/definitions/form_element"
                     }
                 }
             },
@@ -58,7 +58,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element"
+                        "$ref": "#/definitions/form_element"
                     }
                 }
             },
@@ -74,7 +74,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element"
+                        "$ref": "#/definitions/form_element"
                     }
                 }
             },

--- a/packages/assertions/assertions-td/td-vocab-subscription--EventAffordance.json
+++ b/packages/assertions/assertions-td/td-vocab-subscription--EventAffordance.json
@@ -9,18 +9,18 @@
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "event_element": {
             "if": {
                 "type": "object",
                 "properties": {
                     "subscription": {
-                        "$ref": "#/$defs/dataSchema"
+                        "$ref": "#/definitions/dataSchema"
                     }
                 },
                 "required": [
@@ -42,10 +42,10 @@
                     "type": "string"
                 },
                 "descriptions": {
-                    "$ref": "#/$defs/descriptions"
+                    "$ref": "#/definitions/descriptions"
                 },
                 "titles": {
-                    "$ref": "#/$defs/titles"
+                    "$ref": "#/definitions/titles"
                 },
                 "writeOnly": {
                     "type": "boolean"
@@ -56,7 +56,7 @@
                 "oneOf": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/$defs/dataSchema"
+                        "$ref": "#/definitions/dataSchema"
                     }
                 },
                 "unit": {
@@ -82,12 +82,12 @@
                 },
                 "items": {
                     "oneOf": [{
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         },
                         {
                             "type": "array",
                             "items": {
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             }
                         }
                     ]
@@ -112,7 +112,7 @@
                 },
                 "properties": {
                     "additionalProperties": {
-                        "$ref": "#/$defs/dataSchema"
+                        "$ref": "#/definitions/dataSchema"
                     }
                 },
                 "required": {

--- a/packages/assertions/assertions-td/td-vocab-success--AdditionalExpectedResponse.json
+++ b/packages/assertions/assertions-td/td-vocab-success--AdditionalExpectedResponse.json
@@ -9,30 +9,30 @@
             "type": "array",
             "minItems": 1,
             "items": {
-                "$ref": "#/$defs/form_element"
+                "$ref": "#/definitions/form_element"
             }
         },
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
 
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "properties": {
@@ -40,7 +40,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element"
+                        "$ref": "#/definitions/form_element"
                     }
                 }
             },
@@ -56,7 +56,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element"
+                        "$ref": "#/definitions/form_element"
                     }
                 }
             },
@@ -72,7 +72,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element"
+                        "$ref": "#/definitions/form_element"
                     }
                 }
             },
@@ -89,12 +89,12 @@
                      "additionalResponses": {
                         "oneOff": [
                             {
-                                "$ref": "#/$defs/additionalResponse_element"
+                                "$ref": "#/definitions/additionalResponse_element"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/additionalResponse_element"
+                                    "$ref": "#/definitions/additionalResponse_element"
                                 }
                             }
                         ]

--- a/packages/assertions/assertions-td/td-vocab-synchronous--ActionAffordance.json
+++ b/packages/assertions/assertions-td/td-vocab-synchronous--ActionAffordance.json
@@ -8,12 +8,12 @@
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "action_element": {
             "type": "object",
             "if": {
@@ -41,10 +41,10 @@
                     "type": "string"
                 },
                 "descriptions": {
-                    "$ref": "#/$defs/descriptions"
+                    "$ref": "#/definitions/descriptions"
                 },
                 "titles": {
-                    "$ref": "#/$defs/titles"
+                    "$ref": "#/definitions/titles"
                 },
                 "writeOnly": {
                     "type": "boolean"
@@ -55,7 +55,7 @@
                 "oneOf": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/$defs/dataSchema"
+                        "$ref": "#/definitions/dataSchema"
                     }
                 },
                 "unit": {
@@ -81,12 +81,12 @@
                 },
                 "items": {
                     "oneOf": [{
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         },
                         {
                             "type": "array",
                             "items": {
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             }
                         }
                     ]
@@ -111,7 +111,7 @@
                 },
                 "properties": {
                     "additionalProperties": {
-                        "$ref": "#/$defs/dataSchema"
+                        "$ref": "#/definitions/dataSchema"
                     }
                 },
                 "required": {

--- a/packages/assertions/assertions-td/td-vocab-title--DataSchema.json
+++ b/packages/assertions/assertions-td/td-vocab-title--DataSchema.json
@@ -9,31 +9,31 @@
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {
                 "required": ["title"],
                 "properties": {
                     "title": {
-                        "$ref": "#/$defs/title"
+                        "$ref": "#/definitions/title"
                     }
                 }
             },
@@ -44,29 +44,29 @@
                 "properties": {
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "uriVariables": {
                         "type": "object",
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -78,10 +78,10 @@
             "type": "object",
             "properties": {
                 "input": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "output": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -89,13 +89,13 @@
             "type": "object",
             "properties": {
                 "subscription": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "data": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "cancellation": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -105,7 +105,7 @@
                 "required": ["title"],
                 "properties": {
                     "title": {
-                        "$ref": "#/$defs/title"
+                        "$ref": "#/definitions/title"
                     }
                 }
             },
@@ -115,16 +115,16 @@
             "else": {
                 "properties": {
                     "description": {
-                        "$ref": "#/$defs/description"
+                        "$ref": "#/definitions/description"
                     },
                     "title": {
-                        "$ref": "#/$defs/title"
+                        "$ref": "#/definitions/title"
                     },
                     "descriptions": {
-                        "$ref": "#/$defs/descriptions"
+                        "$ref": "#/definitions/descriptions"
                     },
                     "titles": {
-                        "$ref": "#/$defs/titles"
+                        "$ref": "#/definitions/titles"
                     },
                     "writeOnly": {
                         "type": "boolean"
@@ -135,7 +135,7 @@
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "unit": {
@@ -161,12 +161,12 @@
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -189,7 +189,7 @@
                     },
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "required": {

--- a/packages/assertions/assertions-td/td-vocab-title--InteractionAffordance.json
+++ b/packages/assertions/assertions-td/td-vocab-title--InteractionAffordance.json
@@ -8,31 +8,31 @@
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {
                 "required": ["title"],
                 "properties": {
                     "title": {
-                        "$ref": "#/$defs/title"
+                        "$ref": "#/definitions/title"
                     }
                 }
             },
@@ -46,7 +46,7 @@
                 "required": ["title"],
                 "properties": {
                     "title": {
-                        "$ref": "#/$defs/title"
+                        "$ref": "#/definitions/title"
                     }
                 }
             },
@@ -60,7 +60,7 @@
                 "required": ["title"],
                 "properties": {
                     "title": {
-                        "$ref": "#/$defs/title"
+                        "$ref": "#/definitions/title"
                     }
                 }
             },

--- a/packages/assertions/assertions-td/td-vocab-titles--DataSchema.json
+++ b/packages/assertions/assertions-td/td-vocab-titles--DataSchema.json
@@ -9,31 +9,31 @@
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {
                 "required": ["titles"],
                 "properties": {
                     "titles": {
-                        "$ref": "#/$defs/titles"
+                        "$ref": "#/definitions/titles"
                     }
                 }
             },
@@ -44,29 +44,29 @@
                 "properties": {
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "uriVariables": {
                         "type": "object",
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -78,10 +78,10 @@
             "type": "object",
             "properties": {
                 "input": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "output": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -89,13 +89,13 @@
             "type": "object",
             "properties": {
                 "subscription": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "data": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "cancellation": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -105,7 +105,7 @@
                 "required": ["titles"],
                 "properties": {
                     "titles": {
-                        "$ref": "#/$defs/titles"
+                        "$ref": "#/definitions/titles"
                     }
                 }
             },
@@ -115,16 +115,16 @@
             "else": {
                 "properties": {
                     "description": {
-                        "$ref": "#/$defs/description"
+                        "$ref": "#/definitions/description"
                     },
                     "title": {
-                        "$ref": "#/$defs/title"
+                        "$ref": "#/definitions/title"
                     },
                     "descriptions": {
-                        "$ref": "#/$defs/descriptions"
+                        "$ref": "#/definitions/descriptions"
                     },
                     "titles": {
-                        "$ref": "#/$defs/titles"
+                        "$ref": "#/definitions/titles"
                     },
                     "writeOnly": {
                         "type": "boolean"
@@ -135,7 +135,7 @@
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "unit": {
@@ -161,12 +161,12 @@
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -189,7 +189,7 @@
                     },
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "required": {

--- a/packages/assertions/assertions-td/td-vocab-titles--InteractionAffordance.json
+++ b/packages/assertions/assertions-td/td-vocab-titles--InteractionAffordance.json
@@ -9,31 +9,31 @@
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {
                 "required": ["titles"],
                 "properties": {
                     "titles": {
-                        "$ref": "#/$defs/titles"
+                        "$ref": "#/definitions/titles"
                     }
                 }
             },
@@ -47,7 +47,7 @@
                 "required": ["titles"],
                 "properties": {
                     "titles": {
-                        "$ref": "#/$defs/titles"
+                        "$ref": "#/definitions/titles"
                     }
                 }
             },
@@ -61,7 +61,7 @@
                 "required": ["titles"],
                 "properties": {
                     "titles": {
-                        "$ref": "#/$defs/titles"
+                        "$ref": "#/definitions/titles"
                     }
                 }
             },

--- a/packages/assertions/assertions-td/td-vocab-titles--Thing.json
+++ b/packages/assertions/assertions-td/td-vocab-titles--Thing.json
@@ -7,11 +7,11 @@
     "type": "object",
     "properties": {
         "titles": {
-            "$ref": "#/$defs/titles"
+            "$ref": "#/definitions/titles"
         }
     },
     "required": ["titles"],
-    "$defs": {
+    "definitions": {
         "titles": {
             "type": "object",
             "additionalProperties": {

--- a/packages/assertions/assertions-td/td-vocab-token--OAuth2SecurityScheme.json
+++ b/packages/assertions/assertions-td/td-vocab-token--OAuth2SecurityScheme.json
@@ -9,7 +9,7 @@
             "type": "object",
             "minProperties": 1,
             "additionalProperties": {
-                "$ref": "#/$defs/securityScheme"
+                "$ref": "#/definitions/securityScheme"
             }
         }
     },
@@ -17,7 +17,7 @@
         "securityDefinitions"
     ],
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "securityScheme": {
             "if": {
                 "oneOf": [{
@@ -27,7 +27,7 @@
                             "type": "string"
                         },
                         "proxy": {
-                            "$ref": "#/$defs/url"
+                            "$ref": "#/definitions/url"
                         },
                         "scheme": {
                             "type": "string",
@@ -36,13 +36,13 @@
                             ]
                         },
                         "authorization": {
-                            "$ref": "#/$defs/url"
+                            "$ref": "#/definitions/url"
                         },
                         "token": {
-                            "$ref": "#/$defs/url"
+                            "$ref": "#/definitions/url"
                         },
                         "refresh": {
-                            "$ref": "#/$defs/url"
+                            "$ref": "#/definitions/url"
                         },
                         "scopes": {
                             "type": "array",

--- a/packages/assertions/assertions-td/td-vocab-type--DataSchema_array.json
+++ b/packages/assertions/assertions-td/td-vocab-type--DataSchema_array.json
@@ -9,24 +9,24 @@
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {
@@ -48,30 +48,30 @@
                     "uriVariables": {
                         "type": "object",
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
                     },
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     }
                 }
@@ -81,10 +81,10 @@
             "type": "object",
             "properties": {
                 "input": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "output": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -92,13 +92,13 @@
             "type": "object",
             "properties": {
                 "subscription": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "data": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "cancellation": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -121,16 +121,16 @@
             "else": {
                 "properties": {
                     "description": {
-                        "$ref": "#/$defs/description"
+                        "$ref": "#/definitions/description"
                     },
                     "title": {
-                        "$ref": "#/$defs/title"
+                        "$ref": "#/definitions/title"
                     },
                     "descriptions": {
-                        "$ref": "#/$defs/descriptions"
+                        "$ref": "#/definitions/descriptions"
                     },
                     "titles": {
-                        "$ref": "#/$defs/titles"
+                        "$ref": "#/definitions/titles"
                     },
                     "writeOnly": {
                         "type": "boolean"
@@ -141,7 +141,7 @@
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "unit": {
@@ -167,12 +167,12 @@
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -197,7 +197,7 @@
                     },
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "required": {

--- a/packages/assertions/assertions-td/td-vocab-type--DataSchema_boolean.json
+++ b/packages/assertions/assertions-td/td-vocab-type--DataSchema_boolean.json
@@ -9,24 +9,24 @@
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {
@@ -48,30 +48,30 @@
                     "uriVariables": {
                         "type": "object",
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
                     },
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     }
                 }
@@ -81,10 +81,10 @@
             "type": "object",
             "properties": {
                 "input": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "output": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -92,13 +92,13 @@
             "type": "object",
             "properties": {
                 "subscription": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "data": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "cancellation": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -121,16 +121,16 @@
             "else": {
                 "properties": {
                     "description": {
-                        "$ref": "#/$defs/description"
+                        "$ref": "#/definitions/description"
                     },
                     "title": {
-                        "$ref": "#/$defs/title"
+                        "$ref": "#/definitions/title"
                     },
                     "descriptions": {
-                        "$ref": "#/$defs/descriptions"
+                        "$ref": "#/definitions/descriptions"
                     },
                     "titles": {
-                        "$ref": "#/$defs/titles"
+                        "$ref": "#/definitions/titles"
                     },
                     "writeOnly": {
                         "type": "boolean"
@@ -141,7 +141,7 @@
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "unit": {
@@ -167,12 +167,12 @@
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -197,7 +197,7 @@
                     },
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "required": {

--- a/packages/assertions/assertions-td/td-vocab-type--DataSchema_integer.json
+++ b/packages/assertions/assertions-td/td-vocab-type--DataSchema_integer.json
@@ -9,24 +9,24 @@
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {
@@ -48,30 +48,30 @@
                     "uriVariables": {
                         "type": "object",
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
                     },
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     }
                 }
@@ -81,10 +81,10 @@
             "type": "object",
             "properties": {
                 "input": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "output": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -92,13 +92,13 @@
             "type": "object",
             "properties": {
                 "subscription": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "data": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "cancellation": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -121,16 +121,16 @@
             "else": {
                 "properties": {
                     "description": {
-                        "$ref": "#/$defs/description"
+                        "$ref": "#/definitions/description"
                     },
                     "title": {
-                        "$ref": "#/$defs/title"
+                        "$ref": "#/definitions/title"
                     },
                     "descriptions": {
-                        "$ref": "#/$defs/descriptions"
+                        "$ref": "#/definitions/descriptions"
                     },
                     "titles": {
-                        "$ref": "#/$defs/titles"
+                        "$ref": "#/definitions/titles"
                     },
                     "writeOnly": {
                         "type": "boolean"
@@ -141,7 +141,7 @@
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "unit": {
@@ -167,12 +167,12 @@
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -197,7 +197,7 @@
                     },
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "required": {

--- a/packages/assertions/assertions-td/td-vocab-type--DataSchema_null.json
+++ b/packages/assertions/assertions-td/td-vocab-type--DataSchema_null.json
@@ -9,24 +9,24 @@
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {
@@ -48,30 +48,30 @@
                     "uriVariables": {
                         "type": "object",
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
                     },
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     }
                 }
@@ -81,10 +81,10 @@
             "type": "object",
             "properties": {
                 "input": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "output": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -92,13 +92,13 @@
             "type": "object",
             "properties": {
                 "subscription": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "data": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "cancellation": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -121,16 +121,16 @@
             "else": {
                 "properties": {
                     "description": {
-                        "$ref": "#/$defs/description"
+                        "$ref": "#/definitions/description"
                     },
                     "title": {
-                        "$ref": "#/$defs/title"
+                        "$ref": "#/definitions/title"
                     },
                     "descriptions": {
-                        "$ref": "#/$defs/descriptions"
+                        "$ref": "#/definitions/descriptions"
                     },
                     "titles": {
-                        "$ref": "#/$defs/titles"
+                        "$ref": "#/definitions/titles"
                     },
                     "writeOnly": {
                         "type": "boolean"
@@ -141,7 +141,7 @@
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "unit": {
@@ -167,12 +167,12 @@
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -197,7 +197,7 @@
                     },
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "required": {

--- a/packages/assertions/assertions-td/td-vocab-type--DataSchema_number.json
+++ b/packages/assertions/assertions-td/td-vocab-type--DataSchema_number.json
@@ -9,24 +9,24 @@
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {
@@ -48,30 +48,30 @@
                     "uriVariables": {
                         "type": "object",
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
                     },
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     }
                 }
@@ -81,10 +81,10 @@
             "type": "object",
             "properties": {
                 "input": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "output": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -92,13 +92,13 @@
             "type": "object",
             "properties": {
                 "subscription": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "data": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "cancellation": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -121,16 +121,16 @@
             "else": {
                 "properties": {
                     "description": {
-                        "$ref": "#/$defs/description"
+                        "$ref": "#/definitions/description"
                     },
                     "title": {
-                        "$ref": "#/$defs/title"
+                        "$ref": "#/definitions/title"
                     },
                     "descriptions": {
-                        "$ref": "#/$defs/descriptions"
+                        "$ref": "#/definitions/descriptions"
                     },
                     "titles": {
-                        "$ref": "#/$defs/titles"
+                        "$ref": "#/definitions/titles"
                     },
                     "writeOnly": {
                         "type": "boolean"
@@ -141,7 +141,7 @@
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "unit": {
@@ -167,12 +167,12 @@
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -197,7 +197,7 @@
                     },
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "required": {

--- a/packages/assertions/assertions-td/td-vocab-type--DataSchema_object.json
+++ b/packages/assertions/assertions-td/td-vocab-type--DataSchema_object.json
@@ -9,24 +9,24 @@
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {
@@ -48,30 +48,30 @@
                     "uriVariables": {
                         "type": "object",
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
                     },
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     }
                 }
@@ -81,10 +81,10 @@
             "type": "object",
             "properties": {
                 "input": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "output": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -92,13 +92,13 @@
             "type": "object",
             "properties": {
                 "subscription": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "data": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "cancellation": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -121,16 +121,16 @@
             "else": {
                 "properties": {
                     "description": {
-                        "$ref": "#/$defs/description"
+                        "$ref": "#/definitions/description"
                     },
                     "title": {
-                        "$ref": "#/$defs/title"
+                        "$ref": "#/definitions/title"
                     },
                     "descriptions": {
-                        "$ref": "#/$defs/descriptions"
+                        "$ref": "#/definitions/descriptions"
                     },
                     "titles": {
-                        "$ref": "#/$defs/titles"
+                        "$ref": "#/definitions/titles"
                     },
                     "writeOnly": {
                         "type": "boolean"
@@ -141,7 +141,7 @@
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "unit": {
@@ -167,12 +167,12 @@
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -197,7 +197,7 @@
                     },
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "required": {

--- a/packages/assertions/assertions-td/td-vocab-type--DataSchema_string.json
+++ b/packages/assertions/assertions-td/td-vocab-type--DataSchema_string.json
@@ -9,24 +9,24 @@
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {
@@ -48,30 +48,30 @@
                     "uriVariables": {
                         "type": "object",
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
                     },
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     }
                 }
@@ -81,10 +81,10 @@
             "type": "object",
             "properties": {
                 "input": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "output": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -92,13 +92,13 @@
             "type": "object",
             "properties": {
                 "subscription": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "data": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "cancellation": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -121,16 +121,16 @@
             "else": {
                 "properties": {
                     "description": {
-                        "$ref": "#/$defs/description"
+                        "$ref": "#/definitions/description"
                     },
                     "title": {
-                        "$ref": "#/$defs/title"
+                        "$ref": "#/definitions/title"
                     },
                     "descriptions": {
-                        "$ref": "#/$defs/descriptions"
+                        "$ref": "#/definitions/descriptions"
                     },
                     "titles": {
-                        "$ref": "#/$defs/titles"
+                        "$ref": "#/definitions/titles"
                     },
                     "writeOnly": {
                         "type": "boolean"
@@ -141,7 +141,7 @@
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "unit": {
@@ -167,12 +167,12 @@
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -197,7 +197,7 @@
                     },
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "required": {

--- a/packages/assertions/assertions-td/td-vocab-type--Link.json
+++ b/packages/assertions/assertions-td/td-vocab-type--Link.json
@@ -8,12 +8,12 @@
         "links": {
             "type": "array",
             "items": {
-                "$ref": "#/$defs/link_element"
+                "$ref": "#/definitions/link_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "link_element": {
             "if": {
                 "type": "object",

--- a/packages/assertions/assertions-td/td-vocab-unit--DataSchema.json
+++ b/packages/assertions/assertions-td/td-vocab-unit--DataSchema.json
@@ -9,25 +9,25 @@
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
 
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {
@@ -45,29 +45,29 @@
                 "properties": {
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "uriVariables": {
                         "type": "object",
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -79,10 +79,10 @@
             "type": "object",
             "properties": {
                 "input": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "output": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -90,13 +90,13 @@
             "type": "object",
             "properties": {
                 "subscription": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "data": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "cancellation": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -116,16 +116,16 @@
             "else": {
                 "properties": {
                     "description": {
-                        "$ref": "#/$defs/description"
+                        "$ref": "#/definitions/description"
                     },
                     "title": {
-                        "$ref": "#/$defs/title"
+                        "$ref": "#/definitions/title"
                     },
                     "descriptions": {
-                        "$ref": "#/$defs/descriptions"
+                        "$ref": "#/definitions/descriptions"
                     },
                     "titles": {
-                        "$ref": "#/$defs/titles"
+                        "$ref": "#/definitions/titles"
                     },
                     "writeOnly": {
                         "type": "boolean"
@@ -136,7 +136,7 @@
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "unit": {
@@ -162,12 +162,12 @@
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -192,7 +192,7 @@
                     },
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "required": {

--- a/packages/assertions/assertions-td/td-vocab-uriVariables--InteractionAffordance.json
+++ b/packages/assertions/assertions-td/td-vocab-uriVariables--InteractionAffordance.json
@@ -9,25 +9,25 @@
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
 
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {
@@ -36,7 +36,7 @@
                     "uriVariables": {
                         "type": "object",
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     }
                 }
@@ -53,7 +53,7 @@
                     "uriVariables": {
                         "type": "object",
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     }
                 }
@@ -70,7 +70,7 @@
                     "uriVariables": {
                         "type": "object",
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     }
                 }
@@ -89,10 +89,10 @@
                     "type": "string"
                 },
                 "descriptions": {
-                    "$ref": "#/$defs/descriptions"
+                    "$ref": "#/definitions/descriptions"
                 },
                 "titles": {
-                    "$ref": "#/$defs/titles"
+                    "$ref": "#/definitions/titles"
                 },
                 "writeOnly": {
                     "type": "boolean"
@@ -103,7 +103,7 @@
                 "oneOf": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/$defs/dataSchema"
+                        "$ref": "#/definitions/dataSchema"
                     }
                 },
                 "unit": {
@@ -129,12 +129,12 @@
                 },
                 "items": {
                     "oneOf": [{
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         },
                         {
                             "type": "array",
                             "items": {
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             }
                         }
                     ]
@@ -159,7 +159,7 @@
                 },
                 "properties": {
                     "additionalProperties": {
-                        "$ref": "#/$defs/dataSchema"
+                        "$ref": "#/definitions/dataSchema"
                     }
                 },
                 "required": {

--- a/packages/assertions/assertions-td/td-vocab-writeOnly--DataSchema.json
+++ b/packages/assertions/assertions-td/td-vocab-writeOnly--DataSchema.json
@@ -9,24 +9,24 @@
         "properties": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/property_element"
+                "$ref": "#/definitions/property_element"
             }
         },
         "actions": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/action_element"
+                "$ref": "#/definitions/action_element"
             }
         },
         "events": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/$defs/event_element"
+                "$ref": "#/definitions/event_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "property_element": {
             "type": "object",
             "if": {
@@ -44,29 +44,29 @@
                 "properties": {
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "uriVariables": {
                         "type": "object",
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -78,10 +78,10 @@
             "type": "object",
             "properties": {
                 "input": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "output": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -89,13 +89,13 @@
             "type": "object",
             "properties": {
                 "subscription": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "data": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 },
                 "cancellation": {
-                    "$ref": "#/$defs/dataSchema"
+                    "$ref": "#/definitions/dataSchema"
                 }
             }
         },
@@ -115,16 +115,16 @@
             "else": {
                 "properties": {
                     "description": {
-                        "$ref": "#/$defs/description"
+                        "$ref": "#/definitions/description"
                     },
                     "title": {
-                        "$ref": "#/$defs/title"
+                        "$ref": "#/definitions/title"
                     },
                     "descriptions": {
-                        "$ref": "#/$defs/descriptions"
+                        "$ref": "#/definitions/descriptions"
                     },
                     "titles": {
-                        "$ref": "#/$defs/titles"
+                        "$ref": "#/definitions/titles"
                     },
                     "writeOnly": {
                         "type": "boolean"
@@ -135,7 +135,7 @@
                     "oneOf": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "unit": {
@@ -161,12 +161,12 @@
                     },
                     "items": {
                         "oneOf": [{
-                                "$ref": "#/$defs/dataSchema"
+                                "$ref": "#/definitions/dataSchema"
                             },
                             {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/$defs/dataSchema"
+                                    "$ref": "#/definitions/dataSchema"
                                 }
                             }
                         ]
@@ -189,7 +189,7 @@
                     },
                     "properties": {
                         "additionalProperties": {
-                            "$ref": "#/$defs/dataSchema"
+                            "$ref": "#/definitions/dataSchema"
                         }
                     },
                     "required": {

--- a/packages/assertions/assertions-tm/tm-compose-instanceName.json
+++ b/packages/assertions/assertions-tm/tm-compose-instanceName.json
@@ -8,12 +8,12 @@
         "links": {
             "type": "array",
             "items": {
-                "$ref": "#/$defs/link_element"
+                "$ref": "#/definitions/link_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "link_element": {
             "if": {
                 "type": "object",

--- a/packages/assertions/assertions-tm/tm-compose-submodel.json
+++ b/packages/assertions/assertions-tm/tm-compose-submodel.json
@@ -8,12 +8,12 @@
         "links": {
             "type": "array",
             "items": {
-                "$ref": "#/$defs/link_element"
+                "$ref": "#/definitions/link_element"
             }
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "link_element": {
             "if": {
                 "type": "object",

--- a/packages/assertions/assertions-tm/tm-extend.json
+++ b/packages/assertions/assertions-tm/tm-extend.json
@@ -9,10 +9,10 @@
             "type": "array",
             "items": {
                 "if":{
-                    "$ref": "#/$defs/tm_extend_link_element"
+                    "$ref": "#/definitions/tm_extend_link_element"
                 },
                 "else":{
-                    "$ref": "#/$defs/base_link_element"
+                    "$ref": "#/definitions/base_link_element"
                 },
                 "then":{
                     "const": "tm-extend=pass"
@@ -22,7 +22,7 @@
         }
     },
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "anyUri": {
             "type": "string"
         },
@@ -30,7 +30,7 @@
             "type": "object",
             "properties": {
                 "href": {
-                    "$ref": "#/$defs/anyUri"
+                    "$ref": "#/definitions/anyUri"
                 },
                 "type": {
                     "type": "string"
@@ -39,7 +39,7 @@
                     "type": "string"
                 },
                 "anchor": {
-                    "$ref": "#/$defs/anyUri"
+                    "$ref": "#/definitions/anyUri"
                 }
             },
             "required": [
@@ -50,7 +50,7 @@
         "tm_extend_link_element":{
             "allOf": [
                 {
-                    "$ref": "#/$defs/base_link_element"
+                    "$ref": "#/definitions/base_link_element"
                 },
                 {
                     "properties": {

--- a/packages/assertions/assertions-tm/tm-identification.json
+++ b/packages/assertions/assertions-tm/tm-identification.json
@@ -8,7 +8,7 @@
         "@type": {
             "anyOf": [
                 {
-                    "$ref":"#/$defs/tm_string"
+                    "$ref":"#/definitions/tm_string"
                 },
                 {
                     "type": "array",
@@ -16,7 +16,7 @@
                         "type": "string"
                     },
                     "contains": {
-                        "$ref":"#/$defs/tm_string"
+                        "$ref":"#/definitions/tm_string"
                     }
                 }
             ]
@@ -26,7 +26,7 @@
         "@type"
     ],
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "tm_string": {
             "type": "string",
             "const": "tm:ThingModel"

--- a/packages/assertions/assertions-tm/tm-protocol-security-restriction.json
+++ b/packages/assertions/assertions-tm/tm-protocol-security-restriction.json
@@ -3,7 +3,7 @@
     "description": "A Thing Model MAY NOT contain instance specific Protocol Binding and security information such as endpoint addresses.",
     "$schema ": "http://json-schema.org/draft/2019-09/schema#",
     "is-complex":true,
-    "$defs": {
+    "definitions": {
         "anyUri": {
             "type": "string"
         },
@@ -83,10 +83,10 @@
             "type": "object",
             "properties": {
                 "href": {
-                    "$ref": "#/$defs/anyUri"
+                    "$ref": "#/definitions/anyUri"
                 },
                 "security": {
-                    "$ref": "#/$defs/security"
+                    "$ref": "#/definitions/security"
                 }
             },
             "required": [
@@ -97,21 +97,21 @@
         "form_element_property": {
             "allOf": [
                 {
-                    "$ref": "#/$defs/form_element_base"
+                    "$ref": "#/definitions/form_element_base"
                 }
             ]
         },
         "form_element_action": {
             "allOf": [
                 {
-                    "$ref": "#/$defs/form_element_base"
+                    "$ref": "#/definitions/form_element_base"
                 }
             ]
         },
         "form_element_event": {
             "allOf": [
                 {
-                    "$ref": "#/$defs/form_element_base"
+                    "$ref": "#/definitions/form_element_base"
                 }
             ],
             "type": "object"
@@ -119,7 +119,7 @@
         "form_element_root": {
             "allOf": [
                 {
-                    "$ref": "#/$defs/form_element_base"
+                    "$ref": "#/definitions/form_element_base"
                 }
             ],
             "type": "object",
@@ -165,16 +165,16 @@
             "$comment": "This is NOT for validation purposes but for automatic generation of TS types. For more info, please see: https://github.com/w3c/wot-thing-description/pull/1319#issuecomment-994950057",
             "oneOf": [
                 {
-                    "$ref": "#/$defs/form_element_property"
+                    "$ref": "#/definitions/form_element_property"
                 },
                 {
-                    "$ref": "#/$defs/form_element_action"
+                    "$ref": "#/definitions/form_element_action"
                 },
                 {
-                    "$ref": "#/$defs/form_element_event"
+                    "$ref": "#/definitions/form_element_event"
                 },
                 {
-                    "$ref": "#/$defs/form_element_root"
+                    "$ref": "#/definitions/form_element_root"
                 }
             ]
         },
@@ -185,7 +185,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element_property"
+                        "$ref": "#/definitions/form_element_property"
                     }
                 }
             },
@@ -200,7 +200,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element_action"
+                        "$ref": "#/definitions/form_element_action"
                     }
                 }
             },
@@ -216,7 +216,7 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/$defs/form_element_event"
+                        "$ref": "#/definitions/form_element_event"
                     }
                 }
             },
@@ -390,34 +390,34 @@
         "securityScheme": {
             "oneOf": [
                 {
-                    "$ref": "#/$defs/noSecurityScheme"
+                    "$ref": "#/definitions/noSecurityScheme"
                 },
                 {
-                    "$ref": "#/$defs/autoSecurityScheme"
+                    "$ref": "#/definitions/autoSecurityScheme"
                 },
                 {
-                    "$ref": "#/$defs/comboSecurityScheme"
+                    "$ref": "#/definitions/comboSecurityScheme"
                 },
                 {
-                    "$ref": "#/$defs/basicSecurityScheme"
+                    "$ref": "#/definitions/basicSecurityScheme"
                 },
                 {
-                    "$ref": "#/$defs/digestSecurityScheme"
+                    "$ref": "#/definitions/digestSecurityScheme"
                 },
                 {
-                    "$ref": "#/$defs/apiKeySecurityScheme"
+                    "$ref": "#/definitions/apiKeySecurityScheme"
                 },
                 {
-                    "$ref": "#/$defs/bearerSecurityScheme"
+                    "$ref": "#/definitions/bearerSecurityScheme"
                 },
                 {
-                    "$ref": "#/$defs/pskSecurityScheme"
+                    "$ref": "#/definitions/pskSecurityScheme"
                 },
                 {
-                    "$ref": "#/$defs/oAuth2SecurityScheme"
+                    "$ref": "#/definitions/oAuth2SecurityScheme"
                 },
                 {
-                    "$ref": "#/$defs/additionalSecurityScheme"
+                    "$ref": "#/definitions/additionalSecurityScheme"
                 }
             ]
         }
@@ -428,36 +428,36 @@
             "properties": {
                 "type": "object",
                 "additionalProperties": {
-                    "$ref": "#/$defs/property_element"
+                    "$ref": "#/definitions/property_element"
                 }
             },
             "actions": {
                 "type": "object",
                 "additionalProperties": {
-                    "$ref": "#/$defs/action_element"
+                    "$ref": "#/definitions/action_element"
                 }
             },
             "events": {
                 "type": "object",
                 "additionalProperties": {
-                    "$ref": "#/$defs/event_element"
+                    "$ref": "#/definitions/event_element"
                 }
             },
             "forms": {
                 "type": "array",
                 "minItems": 1,
                 "items": {
-                    "$ref": "#/$defs/form_element_root"
+                    "$ref": "#/definitions/form_element_root"
                 }
             },
             "base": {
-                "$ref": "#/$defs/anyUri"
+                "$ref": "#/definitions/anyUri"
             },
             "securityDefinitions": {
                 "type": "object",
                 "minProperties": 1,
                 "additionalProperties": {
-                    "$ref": "#/$defs/securityScheme"
+                    "$ref": "#/definitions/securityScheme"
                 }
             },
             "security": {

--- a/packages/assertions/assertions-tm/tm-tmOptional.json
+++ b/packages/assertions/assertions-tm/tm-tmOptional.json
@@ -9,7 +9,7 @@
         "tm:optional": {
             "type": "array",
             "items": {
-                "$ref": "#/$defs/JSONPointer"
+                "$ref": "#/definitions/JSONPointer"
             }
         }
     },
@@ -17,7 +17,7 @@
         "tm:optional"
     ],
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "JSONPointer": {
             "type": "string",
             "format": "uri-reference"

--- a/packages/assertions/assertions-tm/tm-tmRef1.json
+++ b/packages/assertions/assertions-tm/tm-tmRef1.json
@@ -7,14 +7,14 @@
     "type": "object",
     "properties": {
         "tm:ref": {
-            "$ref": "#/$defs/tm_ref"
+            "$ref": "#/definitions/tm_ref"
         } 
     },
     "required": [
         "tm:ref"
     ],
     "additionalProperties": true,
-    "$defs": {
+    "definitions": {
         "tm_ref": {
             "type": "string",
             "pattern": "^([a-zA-Z][a-zA-Z0-9+\\-.]*:[^\\s]*)(#(?:\/(?:[a-zA-Z0-9_\\-.!$&'()*+,;:=@]|%[0-9a-f]{2}|~0|~1)*)*)$"

--- a/packages/core/td-schema-full.json
+++ b/packages/core/td-schema-full.json
@@ -3,7 +3,7 @@
   "version": "1.1-10-June-2022",
   "description": "JSON Schema for validating TD instances against the TD information model. For a TD to validate this schema it must contain all the default terms defined in Section 5.4",
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$defs": {
+  "definitions": {
     "anyUri": {
       "type": "string"
     },
@@ -74,46 +74,46 @@
           "type": "array",
           "items": [
             {
-              "$ref": "#/$defs/thing-context-td-uri-v1.1"
+              "$ref": "#/definitions/thing-context-td-uri-v1.1"
             }
           ],
           "additionalItems": {
             "anyOf": [
               {
-                "$ref": "#/$defs/anyUri"
+                "$ref": "#/definitions/anyUri"
               },
               {
                 "type": "object"
               }
             ],
             "not": {
-              "$ref": "#/$defs/thing-context-td-uri-v1"
+              "$ref": "#/definitions/thing-context-td-uri-v1"
             }
           }
         },
         {
           "$comment": "Only the new context URI",
-          "$ref": "#/$defs/thing-context-td-uri-v1.1"
+          "$ref": "#/definitions/thing-context-td-uri-v1.1"
         },
         {
           "$comment": "Old context URI, followed by the new one and possibly other vocabularies. minItems and contains are required since prefixItems does not say all items should be provided",
           "type": "array",
           "prefixItems": [
             {
-              "$ref": "#/$defs/thing-context-td-uri-v1"
+              "$ref": "#/definitions/thing-context-td-uri-v1"
             },
             {
-              "$ref": "#/$defs/thing-context-td-uri-v1.1"
+              "$ref": "#/definitions/thing-context-td-uri-v1.1"
             }
           ],
           "minItems": 2,
           "contains": {
-            "$ref": "#/$defs/thing-context-td-uri-v1.1"
+            "$ref": "#/definitions/thing-context-td-uri-v1.1"
           },
           "additionalItems": {
             "anyOf": [
               {
-                "$ref": "#/$defs/anyUri"
+                "$ref": "#/definitions/anyUri"
               },
               {
                 "type": "object"
@@ -126,17 +126,17 @@
           "type": "array",
           "prefixItems": [
             {
-              "$ref": "#/$defs/thing-context-td-uri-v1"
+              "$ref": "#/definitions/thing-context-td-uri-v1"
             }
           ],
           "minItems": 1,
           "contains": {
-            "$ref": "#/$defs/thing-context-td-uri-v1"
+            "$ref": "#/definitions/thing-context-td-uri-v1"
           },
           "additionalItems": {
             "anyOf": [
               {
-                "$ref": "#/$defs/anyUri"
+                "$ref": "#/definitions/anyUri"
               },
               {
                 "type": "object"
@@ -146,7 +146,7 @@
         },
         {
           "$comment": "Only the new context URI",
-          "$ref": "#/$defs/thing-context-td-uri-v1"
+          "$ref": "#/definitions/thing-context-td-uri-v1"
         }
       ]
     },
@@ -185,19 +185,19 @@
       "type": "object",
       "properties": {
         "@type": {
-          "$ref": "#/$defs/type_declaration"
+          "$ref": "#/definitions/type_declaration"
         },
         "description": {
-          "$ref": "#/$defs/description"
+          "$ref": "#/definitions/description"
         },
         "title": {
-          "$ref": "#/$defs/title"
+          "$ref": "#/definitions/title"
         },
         "descriptions": {
-          "$ref": "#/$defs/descriptions"
+          "$ref": "#/definitions/descriptions"
         },
         "titles": {
-          "$ref": "#/$defs/titles"
+          "$ref": "#/definitions/titles"
         },
         "writeOnly": {
           "type": "boolean"
@@ -208,7 +208,7 @@
         "oneOf": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/dataSchema"
+            "$ref": "#/definitions/dataSchema"
           }
         },
         "unit": {
@@ -231,17 +231,17 @@
           "type": "string"
         },
         "type": {
-          "$ref": "#/$defs/dataSchema-type"
+          "$ref": "#/definitions/dataSchema-type"
         },
         "items": {
           "oneOf": [
             {
-              "$ref": "#/$defs/dataSchema"
+              "$ref": "#/definitions/dataSchema"
             },
             {
               "type": "array",
               "items": {
-                "$ref": "#/$defs/dataSchema"
+                "$ref": "#/definitions/dataSchema"
               }
             }
           ]
@@ -275,11 +275,11 @@
           "minimum": 0
         },
         "multipleOf": {
-          "$ref": "#/$defs/multipleOfDefinition"
+          "$ref": "#/definitions/multipleOfDefinition"
         },
         "properties": {
           "additionalProperties": {
-            "$ref": "#/$defs/dataSchema"
+            "$ref": "#/definitions/dataSchema"
           }
         },
         "required": {
@@ -338,7 +338,7 @@
           ]
         },
         "href": {
-          "$ref": "#/$defs/anyUri"
+          "$ref": "#/definitions/anyUri"
         },
         "contentType": {
           "type": "string"
@@ -347,19 +347,19 @@
           "type": "string"
         },
         "subprotocol": {
-          "$ref": "#/$defs/subprotocol"
+          "$ref": "#/definitions/subprotocol"
         },
         "security": {
-          "$ref": "#/$defs/security"
+          "$ref": "#/definitions/security"
         },
         "scopes": {
-          "$ref": "#/$defs/scopes"
+          "$ref": "#/definitions/scopes"
         },
         "response": {
-          "$ref": "#/$defs/expectedResponse"
+          "$ref": "#/definitions/expectedResponse"
         },
         "additionalResponses": {
-          "$ref": "#/$defs/additionalResponsesDefinition"
+          "$ref": "#/definitions/additionalResponsesDefinition"
         }
       },
       "required": ["href", "contentType", "op"],
@@ -368,7 +368,7 @@
     "form_element_property": {
       "allOf": [
         {
-          "$ref": "#/$defs/form_element_base"
+          "$ref": "#/definitions/form_element_base"
         }
       ],
       "type": "object",
@@ -404,7 +404,7 @@
     "form_element_action": {
       "allOf": [
         {
-          "$ref": "#/$defs/form_element_base"
+          "$ref": "#/definitions/form_element_base"
         }
       ],
       "type": "object",
@@ -430,7 +430,7 @@
     "form_element_event": {
       "allOf": [
         {
-          "$ref": "#/$defs/form_element_base"
+          "$ref": "#/definitions/form_element_base"
         }
       ],
       "type": "object",
@@ -456,7 +456,7 @@
     "form_element_root": {
       "allOf": [
         {
-          "$ref": "#/$defs/form_element_base"
+          "$ref": "#/definitions/form_element_base"
         }
       ],
       "type": "object",
@@ -503,16 +503,16 @@
       "$comment": "This is NOT for validation purposes but for automatic generation of TS types. For more info, please see: https://github.com/w3c/wot-thing-description/pull/1319#issuecomment-994950057",
       "oneOf": [
         {
-          "$ref": "#/$defs/form_element_property"
+          "$ref": "#/definitions/form_element_property"
         },
         {
-          "$ref": "#/$defs/form_element_action"
+          "$ref": "#/definitions/form_element_action"
         },
         {
-          "$ref": "#/$defs/form_element_event"
+          "$ref": "#/definitions/form_element_event"
         },
         {
-          "$ref": "#/$defs/form_element_root"
+          "$ref": "#/definitions/form_element_root"
         }
       ]
     },
@@ -520,31 +520,31 @@
       "type": "object",
       "properties": {
         "@type": {
-          "$ref": "#/$defs/type_declaration"
+          "$ref": "#/definitions/type_declaration"
         },
         "description": {
-          "$ref": "#/$defs/description"
+          "$ref": "#/definitions/description"
         },
         "descriptions": {
-          "$ref": "#/$defs/descriptions"
+          "$ref": "#/definitions/descriptions"
         },
         "title": {
-          "$ref": "#/$defs/title"
+          "$ref": "#/definitions/title"
         },
         "titles": {
-          "$ref": "#/$defs/titles"
+          "$ref": "#/definitions/titles"
         },
         "forms": {
           "type": "array",
           "minItems": 1,
           "items": {
-            "$ref": "#/$defs/form_element_property"
+            "$ref": "#/definitions/form_element_property"
           }
         },
         "uriVariables": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/$defs/dataSchema"
+            "$ref": "#/definitions/dataSchema"
           }
         },
         "observable": {
@@ -559,7 +559,7 @@
         "oneOf": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/dataSchema"
+            "$ref": "#/definitions/dataSchema"
           }
         },
         "unit": {
@@ -576,17 +576,17 @@
         "const": {},
         "default": {},
         "type": {
-          "$ref": "#/$defs/dataSchema-type"
+          "$ref": "#/definitions/dataSchema-type"
         },
         "items": {
           "oneOf": [
             {
-              "$ref": "#/$defs/dataSchema"
+              "$ref": "#/definitions/dataSchema"
             },
             {
               "type": "array",
               "items": {
-                "$ref": "#/$defs/dataSchema"
+                "$ref": "#/definitions/dataSchema"
               }
             }
           ]
@@ -620,11 +620,11 @@
           "minimum": 0
         },
         "multipleOf": {
-          "$ref": "#/$defs/multipleOfDefinition"
+          "$ref": "#/definitions/multipleOfDefinition"
         },
         "properties": {
           "additionalProperties": {
-            "$ref": "#/$defs/dataSchema"
+            "$ref": "#/definitions/dataSchema"
           }
         },
         "required": {
@@ -641,38 +641,38 @@
       "type": "object",
       "properties": {
         "@type": {
-          "$ref": "#/$defs/type_declaration"
+          "$ref": "#/definitions/type_declaration"
         },
         "description": {
-          "$ref": "#/$defs/description"
+          "$ref": "#/definitions/description"
         },
         "descriptions": {
-          "$ref": "#/$defs/descriptions"
+          "$ref": "#/definitions/descriptions"
         },
         "title": {
-          "$ref": "#/$defs/title"
+          "$ref": "#/definitions/title"
         },
         "titles": {
-          "$ref": "#/$defs/titles"
+          "$ref": "#/definitions/titles"
         },
         "forms": {
           "type": "array",
           "minItems": 1,
           "items": {
-            "$ref": "#/$defs/form_element_action"
+            "$ref": "#/definitions/form_element_action"
           }
         },
         "uriVariables": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/$defs/dataSchema"
+            "$ref": "#/definitions/dataSchema"
           }
         },
         "input": {
-          "$ref": "#/$defs/dataSchema"
+          "$ref": "#/definitions/dataSchema"
         },
         "output": {
-          "$ref": "#/$defs/dataSchema"
+          "$ref": "#/definitions/dataSchema"
         },
         "safe": {
           "type": "boolean"
@@ -691,44 +691,44 @@
       "type": "object",
       "properties": {
         "@type": {
-          "$ref": "#/$defs/type_declaration"
+          "$ref": "#/definitions/type_declaration"
         },
         "description": {
-          "$ref": "#/$defs/description"
+          "$ref": "#/definitions/description"
         },
         "descriptions": {
-          "$ref": "#/$defs/descriptions"
+          "$ref": "#/definitions/descriptions"
         },
         "title": {
-          "$ref": "#/$defs/title"
+          "$ref": "#/definitions/title"
         },
         "titles": {
-          "$ref": "#/$defs/titles"
+          "$ref": "#/definitions/titles"
         },
         "forms": {
           "type": "array",
           "minItems": 1,
           "items": {
-            "$ref": "#/$defs/form_element_event"
+            "$ref": "#/definitions/form_element_event"
           }
         },
         "uriVariables": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/$defs/dataSchema"
+            "$ref": "#/definitions/dataSchema"
           }
         },
         "subscription": {
-          "$ref": "#/$defs/dataSchema"
+          "$ref": "#/definitions/dataSchema"
         },
         "data": {
-          "$ref": "#/$defs/dataSchema"
+          "$ref": "#/definitions/dataSchema"
         },
         "dataResponse": {
-          "$ref": "#/$defs/dataSchema"
+          "$ref": "#/definitions/dataSchema"
         },
         "cancellation": {
-          "$ref": "#/$defs/dataSchema"
+          "$ref": "#/definitions/dataSchema"
         }
       },
       "required": ["forms"],
@@ -738,7 +738,7 @@
       "type": "object",
       "properties": {
         "href": {
-          "$ref": "#/$defs/anyUri"
+          "$ref": "#/definitions/anyUri"
         },
         "type": {
           "type": "string"
@@ -747,7 +747,7 @@
           "type": "string"
         },
         "anchor": {
-          "$ref": "#/$defs/anyUri"
+          "$ref": "#/definitions/anyUri"
         }
       },
       "required": ["href"],
@@ -756,7 +756,7 @@
     "link_element": {
       "allOf": [
         {
-          "$ref": "#/$defs/base_link_element"
+          "$ref": "#/definitions/base_link_element"
         },
         {
           "not": {
@@ -784,7 +784,7 @@
     "icon_link_element": {
       "allOf": [
         {
-          "$ref": "#/$defs/base_link_element"
+          "$ref": "#/definitions/base_link_element"
         },
         {
           "properties": {
@@ -815,16 +815,16 @@
       "type": "object",
       "properties": {
         "@type": {
-          "$ref": "#/$defs/type_declaration"
+          "$ref": "#/definitions/type_declaration"
         },
         "description": {
-          "$ref": "#/$defs/description"
+          "$ref": "#/definitions/description"
         },
         "descriptions": {
-          "$ref": "#/$defs/descriptions"
+          "$ref": "#/definitions/descriptions"
         },
         "proxy": {
-          "$ref": "#/$defs/anyUri"
+          "$ref": "#/definitions/anyUri"
         },
         "scheme": {
           "type": "string",
@@ -837,16 +837,16 @@
       "type": "object",
       "properties": {
         "@type": {
-          "$ref": "#/$defs/type_declaration"
+          "$ref": "#/definitions/type_declaration"
         },
         "description": {
-          "$ref": "#/$defs/description"
+          "$ref": "#/definitions/description"
         },
         "descriptions": {
-          "$ref": "#/$defs/descriptions"
+          "$ref": "#/definitions/descriptions"
         },
         "proxy": {
-          "$ref": "#/$defs/anyUri"
+          "$ref": "#/definitions/anyUri"
         },
         "scheme": {
           "type": "string",
@@ -859,16 +859,16 @@
       "type": "object",
       "properties": {
         "@type": {
-          "$ref": "#/$defs/type_declaration"
+          "$ref": "#/definitions/type_declaration"
         },
         "description": {
-          "$ref": "#/$defs/description"
+          "$ref": "#/definitions/description"
         },
         "descriptions": {
-          "$ref": "#/$defs/descriptions"
+          "$ref": "#/definitions/descriptions"
         },
         "proxy": {
-          "$ref": "#/$defs/anyUri"
+          "$ref": "#/definitions/anyUri"
         },
         "scheme": {
           "type": "string",
@@ -883,16 +883,16 @@
           "type": "object",
           "properties": {
             "@type": {
-              "$ref": "#/$defs/type_declaration"
+              "$ref": "#/definitions/type_declaration"
             },
             "description": {
-              "$ref": "#/$defs/description"
+              "$ref": "#/definitions/description"
             },
             "descriptions": {
-              "$ref": "#/$defs/descriptions"
+              "$ref": "#/definitions/descriptions"
             },
             "proxy": {
-              "$ref": "#/$defs/anyUri"
+              "$ref": "#/definitions/anyUri"
             },
             "scheme": {
               "type": "string",
@@ -912,16 +912,16 @@
           "type": "object",
           "properties": {
             "@type": {
-              "$ref": "#/$defs/type_declaration"
+              "$ref": "#/definitions/type_declaration"
             },
             "description": {
-              "$ref": "#/$defs/description"
+              "$ref": "#/definitions/description"
             },
             "descriptions": {
-              "$ref": "#/$defs/descriptions"
+              "$ref": "#/definitions/descriptions"
             },
             "proxy": {
-              "$ref": "#/$defs/anyUri"
+              "$ref": "#/definitions/anyUri"
             },
             "scheme": {
               "type": "string",
@@ -943,16 +943,16 @@
       "type": "object",
       "properties": {
         "@type": {
-          "$ref": "#/$defs/type_declaration"
+          "$ref": "#/definitions/type_declaration"
         },
         "description": {
-          "$ref": "#/$defs/description"
+          "$ref": "#/definitions/description"
         },
         "descriptions": {
-          "$ref": "#/$defs/descriptions"
+          "$ref": "#/definitions/descriptions"
         },
         "proxy": {
-          "$ref": "#/$defs/anyUri"
+          "$ref": "#/definitions/anyUri"
         },
         "scheme": {
           "type": "string",
@@ -972,16 +972,16 @@
       "type": "object",
       "properties": {
         "@type": {
-          "$ref": "#/$defs/type_declaration"
+          "$ref": "#/definitions/type_declaration"
         },
         "description": {
-          "$ref": "#/$defs/description"
+          "$ref": "#/definitions/description"
         },
         "descriptions": {
-          "$ref": "#/$defs/descriptions"
+          "$ref": "#/definitions/descriptions"
         },
         "proxy": {
-          "$ref": "#/$defs/anyUri"
+          "$ref": "#/definitions/anyUri"
         },
         "scheme": {
           "type": "string",
@@ -1005,16 +1005,16 @@
       "type": "object",
       "properties": {
         "@type": {
-          "$ref": "#/$defs/type_declaration"
+          "$ref": "#/definitions/type_declaration"
         },
         "description": {
-          "$ref": "#/$defs/description"
+          "$ref": "#/definitions/description"
         },
         "descriptions": {
-          "$ref": "#/$defs/descriptions"
+          "$ref": "#/definitions/descriptions"
         },
         "proxy": {
-          "$ref": "#/$defs/anyUri"
+          "$ref": "#/definitions/anyUri"
         },
         "scheme": {
           "type": "string",
@@ -1041,23 +1041,23 @@
       "type": "object",
       "properties": {
         "@type": {
-          "$ref": "#/$defs/type_declaration"
+          "$ref": "#/definitions/type_declaration"
         },
         "description": {
-          "$ref": "#/$defs/description"
+          "$ref": "#/definitions/description"
         },
         "descriptions": {
-          "$ref": "#/$defs/descriptions"
+          "$ref": "#/definitions/descriptions"
         },
         "proxy": {
-          "$ref": "#/$defs/anyUri"
+          "$ref": "#/definitions/anyUri"
         },
         "scheme": {
           "type": "string",
           "enum": ["bearer"]
         },
         "authorization": {
-          "$ref": "#/$defs/anyUri"
+          "$ref": "#/definitions/anyUri"
         },
         "alg": {
           "type": "string"
@@ -1079,16 +1079,16 @@
       "type": "object",
       "properties": {
         "@type": {
-          "$ref": "#/$defs/type_declaration"
+          "$ref": "#/definitions/type_declaration"
         },
         "description": {
-          "$ref": "#/$defs/description"
+          "$ref": "#/definitions/description"
         },
         "descriptions": {
-          "$ref": "#/$defs/descriptions"
+          "$ref": "#/definitions/descriptions"
         },
         "proxy": {
-          "$ref": "#/$defs/anyUri"
+          "$ref": "#/definitions/anyUri"
         },
         "scheme": {
           "type": "string",
@@ -1104,29 +1104,29 @@
       "type": "object",
       "properties": {
         "@type": {
-          "$ref": "#/$defs/type_declaration"
+          "$ref": "#/definitions/type_declaration"
         },
         "description": {
-          "$ref": "#/$defs/description"
+          "$ref": "#/definitions/description"
         },
         "descriptions": {
-          "$ref": "#/$defs/descriptions"
+          "$ref": "#/definitions/descriptions"
         },
         "proxy": {
-          "$ref": "#/$defs/anyUri"
+          "$ref": "#/definitions/anyUri"
         },
         "scheme": {
           "type": "string",
           "enum": ["oauth2"]
         },
         "authorization": {
-          "$ref": "#/$defs/anyUri"
+          "$ref": "#/definitions/anyUri"
         },
         "token": {
-          "$ref": "#/$defs/anyUri"
+          "$ref": "#/definitions/anyUri"
         },
         "refresh": {
-          "$ref": "#/$defs/anyUri"
+          "$ref": "#/definitions/anyUri"
         },
         "scopes": {
           "oneOf": [
@@ -1158,34 +1158,34 @@
     "securityScheme": {
       "oneOf": [
         {
-          "$ref": "#/$defs/noSecurityScheme"
+          "$ref": "#/definitions/noSecurityScheme"
         },
         {
-          "$ref": "#/$defs/autoSecurityScheme"
+          "$ref": "#/definitions/autoSecurityScheme"
         },
         {
-          "$ref": "#/$defs/comboSecurityScheme"
+          "$ref": "#/definitions/comboSecurityScheme"
         },
         {
-          "$ref": "#/$defs/basicSecurityScheme"
+          "$ref": "#/definitions/basicSecurityScheme"
         },
         {
-          "$ref": "#/$defs/digestSecurityScheme"
+          "$ref": "#/definitions/digestSecurityScheme"
         },
         {
-          "$ref": "#/$defs/apiKeySecurityScheme"
+          "$ref": "#/definitions/apiKeySecurityScheme"
         },
         {
-          "$ref": "#/$defs/bearerSecurityScheme"
+          "$ref": "#/definitions/bearerSecurityScheme"
         },
         {
-          "$ref": "#/$defs/pskSecurityScheme"
+          "$ref": "#/definitions/pskSecurityScheme"
         },
         {
-          "$ref": "#/$defs/oAuth2SecurityScheme"
+          "$ref": "#/definitions/oAuth2SecurityScheme"
         },
         {
-          "$ref": "#/$defs/additionalSecurityScheme"
+          "$ref": "#/definitions/additionalSecurityScheme"
         }
       ]
     }
@@ -1197,34 +1197,34 @@
       "format": "uri"
     },
     "title": {
-      "$ref": "#/$defs/title"
+      "$ref": "#/definitions/title"
     },
     "titles": {
-      "$ref": "#/$defs/titles"
+      "$ref": "#/definitions/titles"
     },
     "properties": {
       "type": "object",
       "additionalProperties": {
-        "$ref": "#/$defs/property_element"
+        "$ref": "#/definitions/property_element"
       }
     },
     "actions": {
       "type": "object",
       "additionalProperties": {
-        "$ref": "#/$defs/action_element"
+        "$ref": "#/definitions/action_element"
       }
     },
     "events": {
       "type": "object",
       "additionalProperties": {
-        "$ref": "#/$defs/event_element"
+        "$ref": "#/definitions/event_element"
       }
     },
     "description": {
-      "$ref": "#/$defs/description"
+      "$ref": "#/definitions/description"
     },
     "descriptions": {
-      "$ref": "#/$defs/descriptions"
+      "$ref": "#/definitions/descriptions"
     },
     "version": {
       "type": "object",
@@ -1240,10 +1240,10 @@
       "items": {
         "oneOf": [
           {
-            "$ref": "#/$defs/link_element"
+            "$ref": "#/definitions/link_element"
           },
           {
-            "$ref": "#/$defs/icon_link_element"
+            "$ref": "#/definitions/icon_link_element"
           }
         ]
       }
@@ -1252,28 +1252,28 @@
       "type": "array",
       "minItems": 1,
       "items": {
-        "$ref": "#/$defs/form_element_root"
+        "$ref": "#/definitions/form_element_root"
       }
     },
     "base": {
-      "$ref": "#/$defs/anyUri"
+      "$ref": "#/definitions/anyUri"
     },
     "securityDefinitions": {
       "type": "object",
       "minProperties": 1,
       "additionalProperties": {
-        "$ref": "#/$defs/securityScheme"
+        "$ref": "#/definitions/securityScheme"
       }
     },
     "schemaDefinitions": {
       "type": "object",
       "minProperties": 1,
       "additionalProperties": {
-        "$ref": "#/$defs/dataSchema"
+        "$ref": "#/definitions/dataSchema"
       }
     },
     "support": {
-      "$ref": "#/$defs/anyUri"
+      "$ref": "#/definitions/anyUri"
     },
     "created": {
       "type": "string",
@@ -1286,13 +1286,13 @@
     "profile": {
       "oneOf": [
         {
-          "$ref": "#/$defs/anyUri"
+          "$ref": "#/definitions/anyUri"
         },
         {
           "type": "array",
           "minItems": 1,
           "items": {
-            "$ref": "#/$defs/anyUri"
+            "$ref": "#/definitions/anyUri"
           }
         }
       ]
@@ -1314,14 +1314,14 @@
     "uriVariables": {
       "type": "object",
       "additionalProperties": {
-        "$ref": "#/$defs/dataSchema"
+        "$ref": "#/definitions/dataSchema"
       }
     },
     "@type": {
-      "$ref": "#/$defs/type_declaration"
+      "$ref": "#/definitions/type_declaration"
     },
     "@context": {
-      "$ref": "#/$defs/thing-context"
+      "$ref": "#/definitions/thing-context"
     }
   },
   "required": ["title", "security", "securityDefinitions", "@context"],

--- a/packages/core/td-schema.json
+++ b/packages/core/td-schema.json
@@ -4,7 +4,7 @@
   "description": "JSON Schema for validating TD instances against the TD information model. TD instances can be with or without terms that have default values",
   "$schema ": "http://json-schema.org/draft-07/schema#",
   "$id": "https://raw.githubusercontent.com/w3c/wot-thing-description/main/validation/td-json-schema-validation.json",
-  "$defs": {
+  "definitions": {
     "anyUri": {
       "type": "string"
     },
@@ -75,46 +75,46 @@
           "type": "array",
           "items": [
             {
-              "$ref": "#/$defs/thing-context-td-uri-v1.1"
+              "$ref": "#/definitions/thing-context-td-uri-v1.1"
             }
           ],
           "additionalItems": {
             "anyOf": [
               {
-                "$ref": "#/$defs/anyUri"
+                "$ref": "#/definitions/anyUri"
               },
               {
                 "type": "object"
               }
             ],
             "not": {
-              "$ref": "#/$defs/thing-context-td-uri-v1"
+              "$ref": "#/definitions/thing-context-td-uri-v1"
             }
           }
         },
         {
           "$comment": "Only the new context URI",
-          "$ref": "#/$defs/thing-context-td-uri-v1.1"
+          "$ref": "#/definitions/thing-context-td-uri-v1.1"
         },
         {
           "$comment": "Old context URI, followed by the new one and possibly other vocabularies. minItems and contains are required since prefixItems does not say all items should be provided",
           "type": "array",
           "prefixItems": [
             {
-              "$ref": "#/$defs/thing-context-td-uri-v1"
+              "$ref": "#/definitions/thing-context-td-uri-v1"
             },
             {
-              "$ref": "#/$defs/thing-context-td-uri-v1.1"
+              "$ref": "#/definitions/thing-context-td-uri-v1.1"
             }
           ],
           "minItems": 2,
           "contains": {
-            "$ref": "#/$defs/thing-context-td-uri-v1.1"
+            "$ref": "#/definitions/thing-context-td-uri-v1.1"
           },
           "additionalItems": {
             "anyOf": [
               {
-                "$ref": "#/$defs/anyUri"
+                "$ref": "#/definitions/anyUri"
               },
               {
                 "type": "object"
@@ -127,17 +127,17 @@
           "type": "array",
           "prefixItems": [
             {
-              "$ref": "#/$defs/thing-context-td-uri-v1"
+              "$ref": "#/definitions/thing-context-td-uri-v1"
             }
           ],
           "minItems": 1,
           "contains": {
-            "$ref": "#/$defs/thing-context-td-uri-v1"
+            "$ref": "#/definitions/thing-context-td-uri-v1"
           },
           "additionalItems": {
             "anyOf": [
               {
-                "$ref": "#/$defs/anyUri"
+                "$ref": "#/definitions/anyUri"
               },
               {
                 "type": "object"
@@ -147,7 +147,7 @@
         },
         {
           "$comment": "Only the new context URI",
-          "$ref": "#/$defs/thing-context-td-uri-v1"
+          "$ref": "#/definitions/thing-context-td-uri-v1"
         }
       ]
     },
@@ -190,19 +190,19 @@
       "type": "object",
       "properties": {
         "@type": {
-          "$ref": "#/$defs/type_declaration"
+          "$ref": "#/definitions/type_declaration"
         },
         "description": {
-          "$ref": "#/$defs/description"
+          "$ref": "#/definitions/description"
         },
         "title": {
-          "$ref": "#/$defs/title"
+          "$ref": "#/definitions/title"
         },
         "descriptions": {
-          "$ref": "#/$defs/descriptions"
+          "$ref": "#/definitions/descriptions"
         },
         "titles": {
-          "$ref": "#/$defs/titles"
+          "$ref": "#/definitions/titles"
         },
         "writeOnly": {
           "type": "boolean"
@@ -213,7 +213,7 @@
         "oneOf": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/dataSchema"
+            "$ref": "#/definitions/dataSchema"
           }
         },
         "unit": {
@@ -236,17 +236,17 @@
           "type": "string"
         },
         "type": {
-          "$ref": "#/$defs/dataSchema-type"
+          "$ref": "#/definitions/dataSchema-type"
         },
         "items": {
           "oneOf": [
             {
-              "$ref": "#/$defs/dataSchema"
+              "$ref": "#/definitions/dataSchema"
             },
             {
               "type": "array",
               "items": {
-                "$ref": "#/$defs/dataSchema"
+                "$ref": "#/definitions/dataSchema"
               }
             }
           ]
@@ -280,11 +280,11 @@
           "minimum": 0
         },
         "multipleOf": {
-          "$ref": "#/$defs/multipleOfDefinition"
+          "$ref": "#/definitions/multipleOfDefinition"
         },
         "properties": {
           "additionalProperties": {
-            "$ref": "#/$defs/dataSchema"
+            "$ref": "#/definitions/dataSchema"
           }
         },
         "required": {
@@ -341,7 +341,7 @@
           ]
         },
         "href": {
-          "$ref": "#/$defs/anyUri"
+          "$ref": "#/definitions/anyUri"
         },
         "contentType": {
           "type": "string"
@@ -350,26 +350,26 @@
           "type": "string"
         },
         "subprotocol": {
-          "$ref": "#/$defs/subprotocol"
+          "$ref": "#/definitions/subprotocol"
         },
         "security": {
-          "$ref": "#/$defs/security"
+          "$ref": "#/definitions/security"
         },
         "scopes": {
-          "$ref": "#/$defs/scopes"
+          "$ref": "#/definitions/scopes"
         },
         "response": {
-          "$ref": "#/$defs/expectedResponse"
+          "$ref": "#/definitions/expectedResponse"
         },
         "additionalResponses": {
-          "$ref": "#/$defs/additionalResponsesDefinition"
+          "$ref": "#/definitions/additionalResponsesDefinition"
         }
       },
       "required": ["href"],
       "additionalProperties": true
     },
     "form_element_property": {
-      "allOf": [{ "$ref": "#/$defs/form_element_base" }],
+      "allOf": [{ "$ref": "#/definitions/form_element_base" }],
       "type": "object",
       "properties": {
         "op": {
@@ -401,7 +401,7 @@
       "additionalProperties": true
     },
     "form_element_action": {
-      "allOf": [{ "$ref": "#/$defs/form_element_base" }],
+      "allOf": [{ "$ref": "#/definitions/form_element_base" }],
       "type": "object",
       "properties": {
         "op": {
@@ -423,7 +423,7 @@
       "additionalProperties": true
     },
     "form_element_event": {
-      "allOf": [{ "$ref": "#/$defs/form_element_base" }],
+      "allOf": [{ "$ref": "#/definitions/form_element_base" }],
       "type": "object",
       "properties": {
         "op": {
@@ -445,7 +445,7 @@
       "additionalProperties": true
     },
     "form_element_root": {
-      "allOf": [{ "$ref": "#/$defs/form_element_base" }],
+      "allOf": [{ "$ref": "#/definitions/form_element_base" }],
       "type": "object",
       "properties": {
         "op": {
@@ -490,41 +490,41 @@
     "form": {
       "$comment": "This is NOT for validation purposes but for automatic generation of TS types. For more info, please see: https://github.com/w3c/wot-thing-description/pull/1319#issuecomment-994950057",
       "oneOf": [
-        { "$ref": "#/$defs/form_element_property" },
-        { "$ref": "#/$defs/form_element_action" },
-        { "$ref": "#/$defs/form_element_event" },
-        { "$ref": "#/$defs/form_element_root" }
+        { "$ref": "#/definitions/form_element_property" },
+        { "$ref": "#/definitions/form_element_action" },
+        { "$ref": "#/definitions/form_element_event" },
+        { "$ref": "#/definitions/form_element_root" }
       ]
     },
     "property_element": {
       "type": "object",
       "properties": {
         "@type": {
-          "$ref": "#/$defs/type_declaration"
+          "$ref": "#/definitions/type_declaration"
         },
         "description": {
-          "$ref": "#/$defs/description"
+          "$ref": "#/definitions/description"
         },
         "descriptions": {
-          "$ref": "#/$defs/descriptions"
+          "$ref": "#/definitions/descriptions"
         },
         "title": {
-          "$ref": "#/$defs/title"
+          "$ref": "#/definitions/title"
         },
         "titles": {
-          "$ref": "#/$defs/titles"
+          "$ref": "#/definitions/titles"
         },
         "forms": {
           "type": "array",
           "minItems": 1,
           "items": {
-            "$ref": "#/$defs/form_element_property"
+            "$ref": "#/definitions/form_element_property"
           }
         },
         "uriVariables": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/$defs/dataSchema"
+            "$ref": "#/definitions/dataSchema"
           }
         },
         "observable": {
@@ -539,7 +539,7 @@
         "oneOf": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/dataSchema"
+            "$ref": "#/definitions/dataSchema"
           }
         },
         "unit": {
@@ -556,17 +556,17 @@
         "const": {},
         "default": {},
         "type": {
-          "$ref": "#/$defs/dataSchema-type"
+          "$ref": "#/definitions/dataSchema-type"
         },
         "items": {
           "oneOf": [
             {
-              "$ref": "#/$defs/dataSchema"
+              "$ref": "#/definitions/dataSchema"
             },
             {
               "type": "array",
               "items": {
-                "$ref": "#/$defs/dataSchema"
+                "$ref": "#/definitions/dataSchema"
               }
             }
           ]
@@ -600,11 +600,11 @@
           "minimum": 0
         },
         "multipleOf": {
-          "$ref": "#/$defs/multipleOfDefinition"
+          "$ref": "#/definitions/multipleOfDefinition"
         },
         "properties": {
           "additionalProperties": {
-            "$ref": "#/$defs/dataSchema"
+            "$ref": "#/definitions/dataSchema"
           }
         },
         "required": {
@@ -621,38 +621,38 @@
       "type": "object",
       "properties": {
         "@type": {
-          "$ref": "#/$defs/type_declaration"
+          "$ref": "#/definitions/type_declaration"
         },
         "description": {
-          "$ref": "#/$defs/description"
+          "$ref": "#/definitions/description"
         },
         "descriptions": {
-          "$ref": "#/$defs/descriptions"
+          "$ref": "#/definitions/descriptions"
         },
         "title": {
-          "$ref": "#/$defs/title"
+          "$ref": "#/definitions/title"
         },
         "titles": {
-          "$ref": "#/$defs/titles"
+          "$ref": "#/definitions/titles"
         },
         "forms": {
           "type": "array",
           "minItems": 1,
           "items": {
-            "$ref": "#/$defs/form_element_action"
+            "$ref": "#/definitions/form_element_action"
           }
         },
         "uriVariables": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/$defs/dataSchema"
+            "$ref": "#/definitions/dataSchema"
           }
         },
         "input": {
-          "$ref": "#/$defs/dataSchema"
+          "$ref": "#/definitions/dataSchema"
         },
         "output": {
-          "$ref": "#/$defs/dataSchema"
+          "$ref": "#/definitions/dataSchema"
         },
         "safe": {
           "type": "boolean"
@@ -671,44 +671,44 @@
       "type": "object",
       "properties": {
         "@type": {
-          "$ref": "#/$defs/type_declaration"
+          "$ref": "#/definitions/type_declaration"
         },
         "description": {
-          "$ref": "#/$defs/description"
+          "$ref": "#/definitions/description"
         },
         "descriptions": {
-          "$ref": "#/$defs/descriptions"
+          "$ref": "#/definitions/descriptions"
         },
         "title": {
-          "$ref": "#/$defs/title"
+          "$ref": "#/definitions/title"
         },
         "titles": {
-          "$ref": "#/$defs/titles"
+          "$ref": "#/definitions/titles"
         },
         "forms": {
           "type": "array",
           "minItems": 1,
           "items": {
-            "$ref": "#/$defs/form_element_event"
+            "$ref": "#/definitions/form_element_event"
           }
         },
         "uriVariables": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/$defs/dataSchema"
+            "$ref": "#/definitions/dataSchema"
           }
         },
         "subscription": {
-          "$ref": "#/$defs/dataSchema"
+          "$ref": "#/definitions/dataSchema"
         },
         "data": {
-          "$ref": "#/$defs/dataSchema"
+          "$ref": "#/definitions/dataSchema"
         },
         "dataResponse": {
-          "$ref": "#/$defs/dataSchema"
+          "$ref": "#/definitions/dataSchema"
         },
         "cancellation": {
-          "$ref": "#/$defs/dataSchema"
+          "$ref": "#/definitions/dataSchema"
         }
       },
       "required": ["forms"],
@@ -718,7 +718,7 @@
       "type": "object",
       "properties": {
         "href": {
-          "$ref": "#/$defs/anyUri"
+          "$ref": "#/definitions/anyUri"
         },
         "type": {
           "type": "string"
@@ -727,15 +727,15 @@
           "type": "string"
         },
         "anchor": {
-          "$ref": "#/$defs/anyUri"
+          "$ref": "#/definitions/anyUri"
         },
         "hreflang": {
           "anyOf": [
-            { "$ref": "#/$defs/bcp47_string" },
+            { "$ref": "#/definitions/bcp47_string" },
             {
               "type": "array",
               "items": {
-                "$ref": "#/$defs/bcp47_string"
+                "$ref": "#/definitions/bcp47_string"
               }
             }
           ]
@@ -747,7 +747,7 @@
     "link_element": {
       "allOf": [
         {
-          "$ref": "#/$defs/base_link_element"
+          "$ref": "#/definitions/base_link_element"
         },
         {
           "not": {
@@ -775,7 +775,7 @@
     "icon_link_element": {
       "allOf": [
         {
-          "$ref": "#/$defs/base_link_element"
+          "$ref": "#/definitions/base_link_element"
         },
         {
           "properties": {
@@ -806,16 +806,16 @@
       "type": "object",
       "properties": {
         "@type": {
-          "$ref": "#/$defs/type_declaration"
+          "$ref": "#/definitions/type_declaration"
         },
         "description": {
-          "$ref": "#/$defs/description"
+          "$ref": "#/definitions/description"
         },
         "descriptions": {
-          "$ref": "#/$defs/descriptions"
+          "$ref": "#/definitions/descriptions"
         },
         "proxy": {
-          "$ref": "#/$defs/anyUri"
+          "$ref": "#/definitions/anyUri"
         },
         "scheme": {
           "type": "string",
@@ -829,16 +829,16 @@
       "type": "object",
       "properties": {
         "@type": {
-          "$ref": "#/$defs/type_declaration"
+          "$ref": "#/definitions/type_declaration"
         },
         "description": {
-          "$ref": "#/$defs/description"
+          "$ref": "#/definitions/description"
         },
         "descriptions": {
-          "$ref": "#/$defs/descriptions"
+          "$ref": "#/definitions/descriptions"
         },
         "proxy": {
-          "$ref": "#/$defs/anyUri"
+          "$ref": "#/definitions/anyUri"
         },
         "scheme": {
           "type": "string",
@@ -852,16 +852,16 @@
       "type": "object",
       "properties": {
         "@type": {
-          "$ref": "#/$defs/type_declaration"
+          "$ref": "#/definitions/type_declaration"
         },
         "description": {
-          "$ref": "#/$defs/description"
+          "$ref": "#/definitions/description"
         },
         "descriptions": {
-          "$ref": "#/$defs/descriptions"
+          "$ref": "#/definitions/descriptions"
         },
         "proxy": {
-          "$ref": "#/$defs/anyUri"
+          "$ref": "#/definitions/anyUri"
         },
         "scheme": {
           "type": "string",
@@ -880,16 +880,16 @@
           "type": "object",
           "properties": {
             "@type": {
-              "$ref": "#/$defs/type_declaration"
+              "$ref": "#/definitions/type_declaration"
             },
             "description": {
-              "$ref": "#/$defs/description"
+              "$ref": "#/definitions/description"
             },
             "descriptions": {
-              "$ref": "#/$defs/descriptions"
+              "$ref": "#/definitions/descriptions"
             },
             "proxy": {
-              "$ref": "#/$defs/anyUri"
+              "$ref": "#/definitions/anyUri"
             },
             "scheme": {
               "type": "string",
@@ -910,16 +910,16 @@
           "type": "object",
           "properties": {
             "@type": {
-              "$ref": "#/$defs/type_declaration"
+              "$ref": "#/definitions/type_declaration"
             },
             "description": {
-              "$ref": "#/$defs/description"
+              "$ref": "#/definitions/description"
             },
             "descriptions": {
-              "$ref": "#/$defs/descriptions"
+              "$ref": "#/definitions/descriptions"
             },
             "proxy": {
-              "$ref": "#/$defs/anyUri"
+              "$ref": "#/definitions/anyUri"
             },
             "scheme": {
               "type": "string",
@@ -942,16 +942,16 @@
       "type": "object",
       "properties": {
         "@type": {
-          "$ref": "#/$defs/type_declaration"
+          "$ref": "#/definitions/type_declaration"
         },
         "description": {
-          "$ref": "#/$defs/description"
+          "$ref": "#/definitions/description"
         },
         "descriptions": {
-          "$ref": "#/$defs/descriptions"
+          "$ref": "#/definitions/descriptions"
         },
         "proxy": {
-          "$ref": "#/$defs/anyUri"
+          "$ref": "#/definitions/anyUri"
         },
         "scheme": {
           "type": "string",
@@ -972,16 +972,16 @@
       "type": "object",
       "properties": {
         "@type": {
-          "$ref": "#/$defs/type_declaration"
+          "$ref": "#/definitions/type_declaration"
         },
         "description": {
-          "$ref": "#/$defs/description"
+          "$ref": "#/definitions/description"
         },
         "descriptions": {
-          "$ref": "#/$defs/descriptions"
+          "$ref": "#/definitions/descriptions"
         },
         "proxy": {
-          "$ref": "#/$defs/anyUri"
+          "$ref": "#/definitions/anyUri"
         },
         "scheme": {
           "type": "string",
@@ -1006,16 +1006,16 @@
       "type": "object",
       "properties": {
         "@type": {
-          "$ref": "#/$defs/type_declaration"
+          "$ref": "#/definitions/type_declaration"
         },
         "description": {
-          "$ref": "#/$defs/description"
+          "$ref": "#/definitions/description"
         },
         "descriptions": {
-          "$ref": "#/$defs/descriptions"
+          "$ref": "#/definitions/descriptions"
         },
         "proxy": {
-          "$ref": "#/$defs/anyUri"
+          "$ref": "#/definitions/anyUri"
         },
         "scheme": {
           "type": "string",
@@ -1036,23 +1036,23 @@
       "type": "object",
       "properties": {
         "@type": {
-          "$ref": "#/$defs/type_declaration"
+          "$ref": "#/definitions/type_declaration"
         },
         "description": {
-          "$ref": "#/$defs/description"
+          "$ref": "#/definitions/description"
         },
         "descriptions": {
-          "$ref": "#/$defs/descriptions"
+          "$ref": "#/definitions/descriptions"
         },
         "proxy": {
-          "$ref": "#/$defs/anyUri"
+          "$ref": "#/definitions/anyUri"
         },
         "scheme": {
           "type": "string",
           "enum": ["bearer"]
         },
         "authorization": {
-          "$ref": "#/$defs/anyUri"
+          "$ref": "#/definitions/anyUri"
         },
         "alg": {
           "type": "string"
@@ -1075,16 +1075,16 @@
       "type": "object",
       "properties": {
         "@type": {
-          "$ref": "#/$defs/type_declaration"
+          "$ref": "#/definitions/type_declaration"
         },
         "description": {
-          "$ref": "#/$defs/description"
+          "$ref": "#/definitions/description"
         },
         "descriptions": {
-          "$ref": "#/$defs/descriptions"
+          "$ref": "#/definitions/descriptions"
         },
         "proxy": {
-          "$ref": "#/$defs/anyUri"
+          "$ref": "#/definitions/anyUri"
         },
         "scheme": {
           "type": "string",
@@ -1101,29 +1101,29 @@
       "type": "object",
       "properties": {
         "@type": {
-          "$ref": "#/$defs/type_declaration"
+          "$ref": "#/definitions/type_declaration"
         },
         "description": {
-          "$ref": "#/$defs/description"
+          "$ref": "#/definitions/description"
         },
         "descriptions": {
-          "$ref": "#/$defs/descriptions"
+          "$ref": "#/definitions/descriptions"
         },
         "proxy": {
-          "$ref": "#/$defs/anyUri"
+          "$ref": "#/definitions/anyUri"
         },
         "scheme": {
           "type": "string",
           "enum": ["oauth2"]
         },
         "authorization": {
-          "$ref": "#/$defs/anyUri"
+          "$ref": "#/definitions/anyUri"
         },
         "token": {
-          "$ref": "#/$defs/anyUri"
+          "$ref": "#/definitions/anyUri"
         },
         "refresh": {
-          "$ref": "#/$defs/anyUri"
+          "$ref": "#/definitions/anyUri"
         },
         "scopes": {
           "oneOf": [
@@ -1156,34 +1156,34 @@
     "securityScheme": {
       "oneOf": [
         {
-          "$ref": "#/$defs/noSecurityScheme"
+          "$ref": "#/definitions/noSecurityScheme"
         },
         {
-          "$ref": "#/$defs/autoSecurityScheme"
+          "$ref": "#/definitions/autoSecurityScheme"
         },
         {
-          "$ref": "#/$defs/comboSecurityScheme"
+          "$ref": "#/definitions/comboSecurityScheme"
         },
         {
-          "$ref": "#/$defs/basicSecurityScheme"
+          "$ref": "#/definitions/basicSecurityScheme"
         },
         {
-          "$ref": "#/$defs/digestSecurityScheme"
+          "$ref": "#/definitions/digestSecurityScheme"
         },
         {
-          "$ref": "#/$defs/apiKeySecurityScheme"
+          "$ref": "#/definitions/apiKeySecurityScheme"
         },
         {
-          "$ref": "#/$defs/bearerSecurityScheme"
+          "$ref": "#/definitions/bearerSecurityScheme"
         },
         {
-          "$ref": "#/$defs/pskSecurityScheme"
+          "$ref": "#/definitions/pskSecurityScheme"
         },
         {
-          "$ref": "#/$defs/oAuth2SecurityScheme"
+          "$ref": "#/definitions/oAuth2SecurityScheme"
         },
         {
-          "$ref": "#/$defs/additionalSecurityScheme"
+          "$ref": "#/definitions/additionalSecurityScheme"
         }
       ]
     }
@@ -1195,34 +1195,34 @@
       "format": "uri"
     },
     "title": {
-      "$ref": "#/$defs/title"
+      "$ref": "#/definitions/title"
     },
     "titles": {
-      "$ref": "#/$defs/titles"
+      "$ref": "#/definitions/titles"
     },
     "properties": {
       "type": "object",
       "additionalProperties": {
-        "$ref": "#/$defs/property_element"
+        "$ref": "#/definitions/property_element"
       }
     },
     "actions": {
       "type": "object",
       "additionalProperties": {
-        "$ref": "#/$defs/action_element"
+        "$ref": "#/definitions/action_element"
       }
     },
     "events": {
       "type": "object",
       "additionalProperties": {
-        "$ref": "#/$defs/event_element"
+        "$ref": "#/definitions/event_element"
       }
     },
     "description": {
-      "$ref": "#/$defs/description"
+      "$ref": "#/definitions/description"
     },
     "descriptions": {
-      "$ref": "#/$defs/descriptions"
+      "$ref": "#/definitions/descriptions"
     },
     "version": {
       "type": "object",
@@ -1238,10 +1238,10 @@
       "items": {
         "oneOf": [
           {
-            "$ref": "#/$defs/link_element"
+            "$ref": "#/definitions/link_element"
           },
           {
-            "$ref": "#/$defs/icon_link_element"
+            "$ref": "#/definitions/icon_link_element"
           }
         ]
       }
@@ -1250,28 +1250,28 @@
       "type": "array",
       "minItems": 1,
       "items": {
-        "$ref": "#/$defs/form_element_root"
+        "$ref": "#/definitions/form_element_root"
       }
     },
     "base": {
-      "$ref": "#/$defs/anyUri"
+      "$ref": "#/definitions/anyUri"
     },
     "securityDefinitions": {
       "type": "object",
       "minProperties": 1,
       "additionalProperties": {
-        "$ref": "#/$defs/securityScheme"
+        "$ref": "#/definitions/securityScheme"
       }
     },
     "schemaDefinitions": {
       "type": "object",
       "minProperties": 1,
       "additionalProperties": {
-        "$ref": "#/$defs/dataSchema"
+        "$ref": "#/definitions/dataSchema"
       }
     },
     "support": {
-      "$ref": "#/$defs/anyUri"
+      "$ref": "#/definitions/anyUri"
     },
     "created": {
       "type": "string",
@@ -1284,13 +1284,13 @@
     "profile": {
       "oneOf": [
         {
-          "$ref": "#/$defs/anyUri"
+          "$ref": "#/definitions/anyUri"
         },
         {
           "type": "array",
           "minItems": 1,
           "items": {
-            "$ref": "#/$defs/anyUri"
+            "$ref": "#/definitions/anyUri"
           }
         }
       ]
@@ -1312,14 +1312,14 @@
     "uriVariables": {
       "type": "object",
       "additionalProperties": {
-        "$ref": "#/$defs/dataSchema"
+        "$ref": "#/definitions/dataSchema"
       }
     },
     "@type": {
-      "$ref": "#/$defs/type_declaration"
+      "$ref": "#/definitions/type_declaration"
     },
     "@context": {
-      "$ref": "#/$defs/thing-context"
+      "$ref": "#/definitions/thing-context"
     }
   },
   "required": ["title", "security", "securityDefinitions", "@context"],


### PR DESCRIPTION
I had to change this since officially we are on draft 7 and that still uses definitions and that is used by the TD. For possible compatibility problems with JSON Schema tools, the TD spec schema should not change and we should align to it.