### PR TITLE
Assertion fixes for CR transition

### DIFF
--- a/packages/assertions/assertions-tm/tm-versioning-2.json
+++ b/packages/assertions/assertions-tm/tm-versioning-2.json
@@ -1,0 +1,36 @@
+{
+    "title": "tm-versioning-2",
+    "description": "Due to the definition of Thing Model the term instance MUST be omitted within the version container.",
+    "$schema ": "https://json-schema.org/draft/2019-09/schema#",
+    "is-complex":false,
+    "type": "object",
+    "properties": {
+        "version": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "model": {
+                    "type": "string"
+                  }
+                },
+                "not": {
+                  "type": "object",
+                  "properties": {
+                    "instance": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "instance"
+                  ]
+                }
+              }
+            ]
+        }
+    },
+    "required": [
+        "version"
+    ],
+    "additionalProperties": true
+}

--- a/packages/assertions/assertions-tm/tmAssertionList.json
+++ b/packages/assertions/assertions-tm/tmAssertionList.json
@@ -1,1 +1,1 @@
-["tm-compose-instanceName.json","tm-compose-submodel.json","tm-extend.json","tm-identification.json","tm-placeholder.json","tm-protocol-security-restriction.json","tm-tmOptional.json","tm-tmRef1.json"]
+["tm-compose-instanceName.json","tm-compose-submodel.json","tm-extend.json","tm-identification.json","tm-placeholder.json","tm-protocol-security-restriction.json","tm-tmOptional.json","tm-tmRef1.json","tm-versioning-2.json"]

--- a/packages/core/examples/tms/invalid/optionalWrongLocation.json
+++ b/packages/core/examples/tms/invalid/optionalWrongLocation.json
@@ -1,0 +1,33 @@
+{
+    "id": "urn:required",
+    "$comment": "example 57 of the spec",
+    "@context": [
+        "https://www.w3.org/2022/wot/td/v1.1"
+    ],
+    "@type": "tm:ThingModel",
+    "title": "Invalid Model due to tmoptional pointing to something else than an interaction affordance",
+    "description": "Lamp Thing Description Model",
+    "tm:optional": [
+        "#/properties/status/type"
+    ],
+    "properties": {
+        "status": {
+            "description": "current status of the lamp (on|off)",
+            "type": "string",
+            "readOnly": true
+        }
+    },
+    "actions": {
+        "toggle": {
+            "description": "Turn the lamp on or off"
+        }
+    },
+    "events": {
+        "overheating": {
+            "description": "Lamp reaches a critical temperature (overheating)",
+            "data": {
+                "type": "string"
+            }
+        }
+    }
+}

--- a/packages/core/examples/tms/valid/optional.json
+++ b/packages/core/examples/tms/valid/optional.json
@@ -8,8 +8,8 @@
     "title": "Valid Model 11",
     "description": "Lamp Thing Description Model",
     "tm:optional": [
-        "#/properties/status",
-        "#/actions/toggle"
+        "/properties/status",
+        "/actions/toggle"
     ],
     "properties": {
         "status": {

--- a/packages/core/examples/tms/valid/version.json
+++ b/packages/core/examples/tms/valid/version.json
@@ -1,0 +1,7 @@
+{
+    "@context": ["https://www.w3.org/2022/wot/td/v1.1"],  
+    "@type" : "tm:ThingModel",
+     "title": "Lamp Thing Model",
+     "description": "Lamp Thing Description Model",
+     "version" : {"instance" : "1.0.0" }
+ }

--- a/packages/core/examples/tms/valid/version.json
+++ b/packages/core/examples/tms/valid/version.json
@@ -1,7 +1,7 @@
 {
     "@context": ["https://www.w3.org/2022/wot/td/v1.1"],  
     "@type" : "tm:ThingModel",
-     "title": "Lamp Thing Model",
-     "description": "Lamp Thing Description Model",
-     "version" : {"instance" : "1.0.0" }
+    "title": "Lamp Thing Model",
+    "description": "Lamp Thing Description Model",
+    "version" : {"model" : "1.0.0" }
  }

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -15,6 +15,8 @@ module.exports.multiLangConsistency = coreAssertions.checkMultiLangConsistency
 module.exports.checkLinksRelTypeCount = coreAssertions.checkLinksRelTypeCount
 module.exports.security = coreAssertions.checkSecurity
 module.exports.checkUriSecurity = coreAssertions.checkUriSecurity
+module.exports.checkTmOptionalPointer = coreAssertions.checkTmOptionalPointer
+
 
 const jsonValidator = require('json-dup-key-validator')
 
@@ -525,7 +527,8 @@ function tdValidator(tdString, logFunc, { checkDefaults=true, checkJsonLd=true }
             propUniqueness: null,
             multiLangConsistency: null,
             linksRelTypeCount: null,
-            readWriteOnly: null
+            readWriteOnly: null,
+            tmOptionalPointer: null
         }
 
         const detailComments = {
@@ -534,7 +537,8 @@ function tdValidator(tdString, logFunc, { checkDefaults=true, checkJsonLd=true }
             propUniqueness: "Checking whether in one interaction pattern there are duplicate names, e.g. two properties called temp.",
             multiLangConsistency: "Checks whether all titles and descriptions have the same language fields.",
             linksRelTypeCount: "Checks whether rel:type is used more than once in the links array",
-            readWriteOnly: "Warns if a property has readOnly or writeOnly set to true conflicting with another property."
+            readWriteOnly: "Warns if a property has readOnly or writeOnly set to true conflicting with another property.",
+            tmOptionalPointer: "Checking whether tm:optional points to an actual affordance"
         }
 
         let tmJson
@@ -561,21 +565,6 @@ function tdValidator(tdString, logFunc, { checkDefaults=true, checkJsonLd=true }
 
             report.schema = "passed"
 
-            // ! No need to do defaults checking
-            // check with full schema
-            // if (checkDefaults) {
-            //     ajv.addSchema(fullTdSchema, 'fulltd')
-            //     const fullValid = ajv.validate('fulltd', tmJson)
-            //     if (fullValid) {
-            //         report.defaults = "passed"
-            //     }
-            //     else {
-            //         report.defaults = "warning"
-            //         logFunc("Optional validation failed:")
-            //         logFunc("> " + ajv.errorsText(filterErrorMessages(ajv.errors)))
-            //     }
-            // }
-
             // do additional checks
             checkEnumConst(tmJson)
             checkPropItems(tmJson)
@@ -591,6 +580,7 @@ function tdValidator(tdString, logFunc, { checkDefaults=true, checkJsonLd=true }
             }
             details.multiLangConsistency = evalAssertion(coreAssertions.checkMultiLangConsistency(tmJson))
             details.linksRelTypeCount = evalAssertion(coreAssertions.checkLinksRelTypeCount(tmJson))
+            details.tmOptionalPointer = evalAssertion(coreAssertions.checkTmOptionalPointer(tmJson))
 
             // determine additional check state
             // passed + warning -> warning

--- a/packages/core/shared.js
+++ b/packages/core/shared.js
@@ -704,7 +704,7 @@ function checkLinksRelTypeCount(td){
  * all other URI variables declared in the TD.
  * @param {object} td The TD to do assertion tests
  */
- function checkUriSecurity(td) {
+function checkUriSecurity(td) {
 
     const results = []
     if (td.hasOwnProperty("securityDefinitions")) {
@@ -889,3 +889,24 @@ function checkLinksRelTypeCount(td){
     }
     return results
 }
+
+/**
+ * When tm:optional uses a pointer, it should point to an actual affordance and only to an affordance, as said by
+ * tm-tmOptional-resolver: The JSON Pointers of tm:optional MUST resolve to an entire interaction affordance Map definition.
+ * JSON Schema checks for the syntax but cannot know if the pointed affordance exists.
+ * This function checks that programmatically
+ * @param {object} td The TD to do assertion tests
+ */
+ function checkTmOptionalPointer(td){
+    /*
+    * This function returns part of the object given in param with the value found when resolving the path. Similar to JSON Pointers.
+    * In case no path is found, the param defaultValue is echoed back
+    * Taken from
+    * https://stackoverflow.com/questions/6491463/accessing-nested-javascript-objects-and-arrays-by-string-path/6491621#6491621
+    **/
+    const resolvePath = (object, path, defaultValue) => path
+        .split(/[\.\[\]\'\"]/)
+        .filter(p => p)
+        .reduce((o, p) => o ? o[p] : defaultValue, object)
+
+ }

--- a/packages/core/shared.js
+++ b/packages/core/shared.js
@@ -17,7 +17,8 @@ module.exports =  {
     checkSecurity,
     checkMultiLangConsistency,
     checkLinksRelTypeCount,
-    checkUriSecurity
+    checkUriSecurity,
+    checkTmOptionalPointer
 }
 
 
@@ -903,10 +904,40 @@ function checkTmOptionalPointer(td){
     * In case no path is found, the param defaultValue is echoed back
     * Taken from
     * https://stackoverflow.com/questions/6491463/accessing-nested-javascript-objects-and-arrays-by-string-path/6491621#6491621
+    * However, tm:optional values start with / so it should be removed first
     **/
     const resolvePath = (object, path, defaultValue) => path
         .split(/[\.\[\]\'\"]/)
         .filter(p => p)
         .reduce((o, p) => o ? o[p] : defaultValue, object)
 
+    let results = []
+    if(td.hasOwnProperty("tm:optional")){
+        td["tm:optional"].forEach(element => {
+            element = element.substring(1);
+            const pathTarget = resolvePath(td,element,"noTarget")
+
+            if(pathTarget === "noTarget"){
+                results.push({
+                    "ID": "tm-tmOptional-resolver",
+                    "Status": "fail",
+                    "Comment": "tm:optional does not resolve to an affordance"
+                })
+            } else {
+                results.push({
+                    "ID": "tm-tmOptional-resolver",
+                    "Status": "pass",
+                    "Comment": ""
+                })
+            }
+        });
+    } else {
+        results.push({
+            "ID": "tm-tmOptional-resolver",
+            "Status": "not-impl",
+            "Comment": "no use of tm:optional"
+        })
+    }
+
+    return results
  }

--- a/packages/core/shared.js
+++ b/packages/core/shared.js
@@ -697,10 +697,10 @@ function checkLinksRelTypeCount(td){
 /**
  * When you have apikey security with the key in uri, you put the name of the urivariable in the name field in
  * securityDefinitions. Ideally, that name appears in href as a uriVariable. See uriSecurity example
- * td-security-in-uri-variable: The URIs provided in interactions where a security scheme using uri as the value for 
+ * td-security-in-uri-variable: The URIs provided in interactions where a security scheme using uri as the value for
  * in MUST be a URI template including the defined variable.
  * Additionally, this also checks that the uriVariable used in the security does not conflict with ones for the TD
- * td-security-uri-variables-distinct: The names of URI variables declared in a SecurityScheme MUST be distinct from 
+ * td-security-uri-variables-distinct: The names of URI variables declared in a SecurityScheme MUST be distinct from
  * all other URI variables declared in the TD.
  * @param {object} td The TD to do assertion tests
  */
@@ -897,7 +897,7 @@ function checkUriSecurity(td) {
  * This function checks that programmatically
  * @param {object} td The TD to do assertion tests
  */
- function checkTmOptionalPointer(td){
+function checkTmOptionalPointer(td){
     /*
     * This function returns part of the object given in param with the value found when resolving the path. Similar to JSON Pointers.
     * In case no path is found, the param defaultValue is echoed back

--- a/packages/core/shared.js
+++ b/packages/core/shared.js
@@ -21,6 +21,20 @@ module.exports =  {
     checkTmOptionalPointer
 }
 
+/**
+ * This function returns part of the object given in param with the value found when resolving the path. Similar to JSON Pointers.
+ * In case no path is found, the param defaultValue is echoed back
+ * Taken from
+ * https://stackoverflow.com/questions/6491463/accessing-nested-javascript-objects-and-arrays-by-string-path/6491621#6491621
+ * @param {object} object
+ * @param {string} path
+ * @param {any} defaultValue
+ * @return {object}
+ **/
+const resolvePath = (object, path, defaultValue) => path
+    .split(/[\.\[\]\'\"]/)
+    .filter(p => p)
+    .reduce((o, p) => o ? o[p] : defaultValue, object)
 
 // -------------------------------------------------- checkPropUniqueness
 
@@ -899,25 +913,14 @@ function checkUriSecurity(td) {
  * @param {object} td The TD to do assertion tests
  */
 function checkTmOptionalPointer(td){
-    /*
-    * This function returns part of the object given in param with the value found when resolving the path. Similar to JSON Pointers.
-    * In case no path is found, the param defaultValue is echoed back
-    * Taken from
-    * https://stackoverflow.com/questions/6491463/accessing-nested-javascript-objects-and-arrays-by-string-path/6491621#6491621
-    * However, tm:optional values start with / so it should be removed first
-    **/
-    const resolvePath = (object, path, defaultValue) => path
-        .split(/[\.\[\]\'\"]/)
-        .filter(p => p)
-        .reduce((o, p) => o ? o[p] : defaultValue, object)
-
-    let results = []
+    const results = []
     if(td.hasOwnProperty("tm:optional")){
         td["tm:optional"].forEach(element => {
-            element = element.substring(1);
+            // However, tm: optional values start with / so it should be removed first
+            element = element.substring(1)
+            element = element.replace("/",".") // since the resolvePath uses . instead of /
             const pathTarget = resolvePath(td,element,"noTarget")
-
-            if(pathTarget === "noTarget"){
+            if (pathTarget === "noTarget" || pathTarget === undefined) {
                 results.push({
                     "ID": "tm-tmOptional-resolver",
                     "Status": "fail",

--- a/packages/core/td-schema.json
+++ b/packages/core/td-schema.json
@@ -1,8 +1,8 @@
 {
   "title": "Thing Description",
-  "version": "1.1-10-June-2022",
+  "version": "1.1-05-September-2022",
   "description": "JSON Schema for validating TD instances against the TD information model. TD instances can be with or without terms that have default values",
-  "$schema ": "http://json-schema.org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://raw.githubusercontent.com/w3c/wot-thing-description/main/validation/td-json-schema-validation.json",
   "definitions": {
     "anyUri": {
@@ -32,7 +32,8 @@
           "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "minItems": 1
         },
         {
           "type": "string"
@@ -868,8 +869,8 @@
           "enum": ["auto"]
         }
       },
-      "not":{
-        "required":["name"]
+      "not": {
+        "required": ["name"]
       },
       "required": ["scheme"],
       "additionalProperties": true

--- a/packages/core/tm-schema.json
+++ b/packages/core/tm-schema.json
@@ -1,8 +1,9 @@
 {
   "title": "Thing Model",
-  "version": "1.1-10-June-2022",
+  "version": "1.1-05-September-2022",
   "description": "JSON Schema for validating Thing Models. This is automatically generated from the WoT TD Schema.",
-  "$schema ": "http://json-schema.org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/w3c/wot-thing-description/main/validation/tm-json-schema-validation.json",
   "definitions": {
     "anyUri": {
       "type": "string"
@@ -63,11 +64,7 @@
     },
     "subprotocol": {
       "type": "string",
-      "examples": [
-        "longpoll",
-        "websub",
-        "sse"
-      ]
+      "examples": ["longpoll", "websub", "sse"]
     },
     "thing-context-td-uri-v1": {
       "type": "string",
@@ -163,6 +160,10 @@
           "$ref": "#/definitions/thing-context-td-uri-v1"
         }
       ]
+    },
+    "bcp47_string": {
+      "type": "string",
+      "pattern": "^(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)|((en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang)))$"
     },
     "type_declaration": {
       "oneOf": [
@@ -403,10 +404,7 @@
     "multipleOfDefinition": {
       "anyOf": [
         {
-          "type": [
-            "integer",
-            "number"
-          ],
+          "type": ["integer", "number"],
           "exclusiveMinimum": 0
         },
         {
@@ -547,11 +545,7 @@
               "type": "string",
               "anyOf": [
                 {
-                  "enum": [
-                    "invokeaction",
-                    "queryaction",
-                    "cancelaction"
-                  ]
+                  "enum": ["invokeaction", "queryaction", "cancelaction"]
                 },
                 {
                   "$ref": "#/definitions/placeholder-pattern"
@@ -564,11 +558,7 @@
                 "type": "string",
                 "anyOf": [
                   {
-                    "enum": [
-                      "invokeaction",
-                      "queryaction",
-                      "cancelaction"
-                    ]
+                    "enum": ["invokeaction", "queryaction", "cancelaction"]
                   },
                   {
                     "$ref": "#/definitions/placeholder-pattern"
@@ -603,10 +593,7 @@
               "type": "string",
               "anyOf": [
                 {
-                  "enum": [
-                    "subscribeevent",
-                    "unsubscribeevent"
-                  ]
+                  "enum": ["subscribeevent", "unsubscribeevent"]
                 },
                 {
                   "$ref": "#/definitions/placeholder-pattern"
@@ -619,10 +606,7 @@
                 "type": "string",
                 "anyOf": [
                   {
-                    "enum": [
-                      "subscribeevent",
-                      "unsubscribeevent"
-                    ]
+                    "enum": ["subscribeevent", "unsubscribeevent"]
                   },
                   {
                     "$ref": "#/definitions/placeholder-pattern"
@@ -1095,6 +1079,19 @@
         "anchor": {
           "$ref": "#/definitions/anyUri"
         },
+        "hreflang": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/bcp47_string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/bcp47_string"
+              }
+            }
+          ]
+        },
         "instanceName": {
           "type": "string"
         }
@@ -1118,9 +1115,7 @@
             "properties": {
               "sizes": {}
             },
-            "required": [
-              "sizes"
-            ]
+            "required": ["sizes"]
           }
         },
         {
@@ -1130,9 +1125,7 @@
               "rel": {
                 "anyOf": [
                   {
-                    "enum": [
-                      "icon"
-                    ]
+                    "enum": ["icon"]
                   },
                   {
                     "$ref": "#/definitions/placeholder-pattern"
@@ -1140,9 +1133,7 @@
                 ]
               }
             },
-            "required": [
-              "rel"
-            ]
+            "required": ["rel"]
           }
         }
       ]
@@ -1162,9 +1153,7 @@
               "pattern": "[0-9]*x[0-9]+"
             }
           },
-          "required": [
-            "rel"
-          ]
+          "required": ["rel"]
         }
       ]
     },
@@ -1176,10 +1165,7 @@
           "scheme": "ace:ACESecurityScheme",
           "ace:as": "coaps://as.example.com/token",
           "ace:audience": "coaps://rs.example.com",
-          "ace:scopes": [
-            "limited",
-            "special"
-          ],
+          "ace:scopes": ["limited", "special"],
           "ace:cnonce": true
         }
       ],
@@ -1202,6 +1188,7 @@
           "pattern": ".+:.*"
         }
       },
+      "additionalProperties": true,
       "propertyNames": {
         "not": {
           "$ref": "#/definitions/placeholder-pattern"
@@ -1227,9 +1214,7 @@
           "type": "string",
           "anyOf": [
             {
-              "enum": [
-                "nosec"
-              ]
+              "enum": ["nosec"]
             },
             {
               "$ref": "#/definitions/placeholder-pattern"
@@ -1240,6 +1225,7 @@
           "$ref": "#/definitions/tm_ref"
         }
       },
+      "additionalProperties": true,
       "propertyNames": {
         "not": {
           "$ref": "#/definitions/placeholder-pattern"
@@ -1265,9 +1251,7 @@
           "type": "string",
           "anyOf": [
             {
-              "enum": [
-                "auto"
-              ]
+              "enum": ["auto"]
             },
             {
               "$ref": "#/definitions/placeholder-pattern"
@@ -1275,6 +1259,10 @@
           ]
         }
       },
+      "not": {
+        "required": ["name"]
+      },
+      "additionalProperties": true,
       "propertyNames": {
         "not": {
           "$ref": "#/definitions/placeholder-pattern"
@@ -1302,9 +1290,7 @@
               "type": "string",
               "anyOf": [
                 {
-                  "enum": [
-                    "combo"
-                  ]
+                  "enum": ["combo"]
                 },
                 {
                   "$ref": "#/definitions/placeholder-pattern"
@@ -1321,7 +1307,8 @@
             "tm:ref": {
               "$ref": "#/definitions/tm_ref"
             }
-          }
+          },
+          "additionalProperties": true
         },
         {
           "type": "object",
@@ -1342,9 +1329,7 @@
               "type": "string",
               "anyOf": [
                 {
-                  "enum": [
-                    "combo"
-                  ]
+                  "enum": ["combo"]
                 },
                 {
                   "$ref": "#/definitions/placeholder-pattern"
@@ -1361,7 +1346,8 @@
             "tm:ref": {
               "$ref": "#/definitions/tm_ref"
             }
-          }
+          },
+          "additionalProperties": true
         }
       ]
     },
@@ -1384,9 +1370,7 @@
           "type": "string",
           "anyOf": [
             {
-              "enum": [
-                "basic"
-              ]
+              "enum": ["basic"]
             },
             {
               "$ref": "#/definitions/placeholder-pattern"
@@ -1397,13 +1381,7 @@
           "type": "string",
           "anyOf": [
             {
-              "enum": [
-                "header",
-                "query",
-                "body",
-                "cookie",
-                "auto"
-              ]
+              "enum": ["header", "query", "body", "cookie", "auto"]
             },
             {
               "$ref": "#/definitions/placeholder-pattern"
@@ -1417,6 +1395,7 @@
           "$ref": "#/definitions/tm_ref"
         }
       },
+      "additionalProperties": true,
       "propertyNames": {
         "not": {
           "$ref": "#/definitions/placeholder-pattern"
@@ -1442,9 +1421,7 @@
           "type": "string",
           "anyOf": [
             {
-              "enum": [
-                "digest"
-              ]
+              "enum": ["digest"]
             },
             {
               "$ref": "#/definitions/placeholder-pattern"
@@ -1455,10 +1432,7 @@
           "type": "string",
           "anyOf": [
             {
-              "enum": [
-                "auth",
-                "auth-int"
-              ]
+              "enum": ["auth", "auth-int"]
             },
             {
               "$ref": "#/definitions/placeholder-pattern"
@@ -1469,13 +1443,7 @@
           "type": "string",
           "anyOf": [
             {
-              "enum": [
-                "header",
-                "query",
-                "body",
-                "cookie",
-                "auto"
-              ]
+              "enum": ["header", "query", "body", "cookie", "auto"]
             },
             {
               "$ref": "#/definitions/placeholder-pattern"
@@ -1489,6 +1457,7 @@
           "$ref": "#/definitions/tm_ref"
         }
       },
+      "additionalProperties": true,
       "propertyNames": {
         "not": {
           "$ref": "#/definitions/placeholder-pattern"
@@ -1514,9 +1483,7 @@
           "type": "string",
           "anyOf": [
             {
-              "enum": [
-                "apikey"
-              ]
+              "enum": ["apikey"]
             },
             {
               "$ref": "#/definitions/placeholder-pattern"
@@ -1527,14 +1494,7 @@
           "type": "string",
           "anyOf": [
             {
-              "enum": [
-                "header",
-                "query",
-                "body",
-                "cookie",
-                "uri",
-                "auto"
-              ]
+              "enum": ["header", "query", "body", "cookie", "uri", "auto"]
             },
             {
               "$ref": "#/definitions/placeholder-pattern"
@@ -1548,6 +1508,7 @@
           "$ref": "#/definitions/tm_ref"
         }
       },
+      "additionalProperties": true,
       "propertyNames": {
         "not": {
           "$ref": "#/definitions/placeholder-pattern"
@@ -1573,9 +1534,7 @@
           "type": "string",
           "anyOf": [
             {
-              "enum": [
-                "bearer"
-              ]
+              "enum": ["bearer"]
             },
             {
               "$ref": "#/definitions/placeholder-pattern"
@@ -1595,13 +1554,7 @@
           "type": "string",
           "anyOf": [
             {
-              "enum": [
-                "header",
-                "query",
-                "body",
-                "cookie",
-                "auto"
-              ]
+              "enum": ["header", "query", "body", "cookie", "auto"]
             },
             {
               "$ref": "#/definitions/placeholder-pattern"
@@ -1615,6 +1568,7 @@
           "$ref": "#/definitions/tm_ref"
         }
       },
+      "additionalProperties": true,
       "propertyNames": {
         "not": {
           "$ref": "#/definitions/placeholder-pattern"
@@ -1640,9 +1594,7 @@
           "type": "string",
           "anyOf": [
             {
-              "enum": [
-                "psk"
-              ]
+              "enum": ["psk"]
             },
             {
               "$ref": "#/definitions/placeholder-pattern"
@@ -1656,6 +1608,7 @@
           "$ref": "#/definitions/tm_ref"
         }
       },
+      "additionalProperties": true,
       "propertyNames": {
         "not": {
           "$ref": "#/definitions/placeholder-pattern"
@@ -1681,9 +1634,7 @@
           "type": "string",
           "anyOf": [
             {
-              "enum": [
-                "oauth2"
-              ]
+              "enum": ["oauth2"]
             },
             {
               "$ref": "#/definitions/placeholder-pattern"
@@ -1721,11 +1672,7 @@
               "type": "string",
               "anyOf": [
                 {
-                  "enum": [
-                    "code",
-                    "client",
-                    "device"
-                  ]
+                  "enum": ["code", "client", "device"]
                 },
                 {
                   "$ref": "#/definitions/placeholder-pattern"
@@ -1738,6 +1685,7 @@
           "$ref": "#/definitions/tm_ref"
         }
       },
+      "additionalProperties": true,
       "propertyNames": {
         "not": {
           "$ref": "#/definitions/placeholder-pattern"
@@ -1866,7 +1814,7 @@
         {
           "type": "object",
           "properties": {
-            "instance": {
+            "model": {
               "type": "string"
             }
           },
@@ -1874,6 +1822,15 @@
             "not": {
               "$ref": "#/definitions/placeholder-pattern"
             }
+          },
+          "not": {
+            "type": "object",
+            "properties": {
+              "instance": {
+                "type": "string"
+              }
+            },
+            "required": ["instance"]
           }
         },
         {
@@ -1992,8 +1949,5 @@
       "$ref": "#/definitions/placeholder-pattern"
     }
   },
-  "required": [
-    "@context",
-    "@type"
-  ]
+  "required": ["@context", "@type"]
 }

--- a/packages/core/tm-schema.json
+++ b/packages/core/tm-schema.json
@@ -1750,8 +1750,21 @@
     "tm_optional": {
       "type": "array",
       "items": {
-        "type": "string",
-        "format": "json-pointer"
+        "$comment": "this first checks for the general structure of /properties/myProp and then prohibits using / 3 times",
+        "allOf": [
+          {
+            "type": "string",
+            "pattern": "^((/properties/)|(/actions/)|(/events/))(([^/]))",
+            "$comment": "regex tests available at https://regex101.com/r/UgOzrJ/1"
+          },
+          {
+            "not": {
+              "type": "string",
+              "pattern": "(/)(.*\\1){2}",
+              "$comment": "regex tests available at https://regex101.com/r/Ytzd72/1"
+            }
+          }
+        ]
       }
     },
     "tm_ref": {


### PR DESCRIPTION
This PR is (or will until ready) implementing the following assertions of the td spec:

- [x] [sec-body-name-json-pointer](https://w3c.github.io/wot-thing-description#sec-body-name-json-pointer)
- [x] [sec-body-name-json-pointer-array](https://w3c.github.io/wot-thing-description#sec-body-name-json-pointer-array)
- [x] [tm-versioning-2](https://w3c.github.io/wot-thing-description#tm-versioning-2)
- [x] [tm-tmOptional-resolver](https://w3c.github.io/wot-thing-description#tm-tmOptional-resolver)