### PR TITLE
add missing toString

### DIFF
--- a/packages/web/jsonld-vis.js
+++ b/packages/web/jsonld-vis.js
@@ -234,7 +234,7 @@ export function jsonldVis(jsonld, selector, config) {
       }
     }
 
-    return getDirectionSymbol(source[key].getDirection()) + source[key];
+    return getDirectionSymbol(source[key].toString().getDirection()) + source[key];
   }
 
   function jsonldTree(source, parentKey) {


### PR DESCRIPTION
While working on the related PR for ediTDor, I've realized that there is `toString()` missing.