### PR TITLE
monaco highlight firefox issue fixed

### DIFF
--- a/packages/web/style.css
+++ b/packages/web/style.css
@@ -50,8 +50,8 @@ body {
 	overflow-y: scroll;
 }
 
-#td-editor, #tm-editor {
-	height: 100%;
+#td-editor, #tm-editor, #open-api-editor, #async-api {
+	max-height: 100vh;
 	width: auto;
 }
 


### PR DESCRIPTION
Fixed values on the wrappers #td-editor, #tm-editor, #open-api-editor, #async-api to a max-height of 100vh to avoid the infinite overflow from the monaco editor